### PR TITLE
Renames zipkin-query to zipkin-spanstore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <modules>
     <module>swift-codec</module>
     <module>zipkin-java-core</module>
-    <module>zipkin-java-query</module>
+    <module>zipkin-java-spanstore</module>
     <module>zipkin-java-scribe</module>
     <module>zipkin-java-dependencies</module>
     <module>zipkin-java-server</module>
@@ -112,13 +112,13 @@
 
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-java-query</artifactId>
+        <artifactId>zipkin-java-spanstore</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-java-query</artifactId>
+        <artifactId>zipkin-java-spanstore</artifactId>
         <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>

--- a/zipkin-java-jdbc/pom.xml
+++ b/zipkin-java-jdbc/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-java-query</artifactId>
+      <artifactId>zipkin-java-spanstore</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
@@ -22,9 +22,9 @@ import io.zipkin.Span;
 import io.zipkin.Trace;
 import io.zipkin.internal.Nullable;
 import io.zipkin.jdbc.internal.generated.tables.ZipkinAnnotations;
-import io.zipkin.query.QueryException;
-import io.zipkin.query.QueryRequest;
-import io.zipkin.query.ZipkinQuery;
+import io.zipkin.spanstore.QueryException;
+import io.zipkin.spanstore.QueryRequest;
+import io.zipkin.spanstore.SpanStore;
 import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -34,7 +34,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import javax.sql.DataSource;
 import org.jooq.DSLContext;
 import org.jooq.InsertSetMoreStep;
@@ -51,7 +50,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.groupingBy;
 
-public final class JDBCZipkinQuery implements ZipkinQuery, Consumer<List<Span>> {
+public final class JDBCSpanStore implements SpanStore {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
   {
     System.setProperty("org.jooq.no-logo", "true");
@@ -59,7 +58,7 @@ public final class JDBCZipkinQuery implements ZipkinQuery, Consumer<List<Span>> 
 
   private final DataSource datasource;
 
-  public JDBCZipkinQuery(DataSource datasource) {
+  public JDBCSpanStore(DataSource datasource) {
     this.datasource = datasource;
   }
 
@@ -254,7 +253,7 @@ public final class JDBCZipkinQuery implements ZipkinQuery, Consumer<List<Span>> 
     abstract long spanId();
 
     static SpanKey create(long traceId, long spanId) {
-      return new AutoValue_JDBCZipkinQuery_SpanKey(traceId, spanId);
+      return new AutoValue_JDBCSpanStore_SpanKey(traceId, spanId);
     }
   }
 

--- a/zipkin-java-server/pom.xml
+++ b/zipkin-java-server/pom.xml
@@ -41,7 +41,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-java-query</artifactId>
+      <artifactId>zipkin-java-spanstore</artifactId>
     </dependency>
 
     <dependency>

--- a/zipkin-java-spanstore/pom.xml
+++ b/zipkin-java-spanstore/pom.xml
@@ -25,9 +25,9 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-java-query</artifactId>
-  <name>Zipkin Java Query</name>
-  <description>Zipkin Java Query</description>
+  <artifactId>zipkin-java-spanstore</artifactId>
+  <name>Zipkin Java SpanStore</name>
+  <description>Zipkin Java SpanStore</description>
 
   <dependencies>
     <dependency>
@@ -40,10 +40,11 @@
       <artifactId>swift-annotations</artifactId>
     </dependency>
 
-    <!-- for ZipkinQuerySpanStoreAdapter -->
+    <!-- for ScalaSpanStoreAdapter -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>swift-codec</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Dependencies for SpanStoreSpec -->

--- a/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/InMemorySpanStore.java
+++ b/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/InMemorySpanStore.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
 import io.zipkin.Annotation;
 import io.zipkin.BinaryAnnotation;
@@ -29,12 +29,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public final class InMemoryZipkinQuery implements ZipkinQuery, Consumer<List<Span>> {
+public final class InMemorySpanStore implements SpanStore {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final Multimap<Long, Span> traceIdToSpans = new Multimap<>(LinkedList::new);

--- a/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/QueryException.java
+++ b/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/QueryException.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
 import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;

--- a/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/QueryRequest.java
+++ b/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/QueryRequest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
 import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;

--- a/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/SpanStore.java
+++ b/zipkin-java-spanstore/src/main/java/io/zipkin/spanstore/SpanStore.java
@@ -11,43 +11,50 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.service.ThriftException;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
+import io.zipkin.Span;
 import io.zipkin.Trace;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
-@ThriftService("ZipkinQuery")
-public interface ZipkinQuery {
+@ThriftService("SpanStore")
+public interface SpanStore extends Consumer<List<Span>> {
 
-  @ThriftMethod(value = "getTraces",
-      exception = {
-          @ThriftException(type = QueryException.class, id = 1)
-      }) List<Trace> getTraces(
-      @ThriftField(value = 1) QueryRequest request
-  ) throws QueryException;
+  /**
+   * Sinks the given spans, ignoring duplicate annotations.
+   */
+  @Override
+  void accept(List<Span> spans);
+
+  @ThriftMethod(
+      value = "getTraces",
+      exception = @ThriftException(type = QueryException.class, id = 1)
+  )
+  List<Trace> getTraces(@ThriftField(value = 1) QueryRequest request) throws QueryException;
 
   @ThriftMethod(value = "getTracesByIds",
-      exception = {
-          @ThriftException(type = QueryException.class, id = 1)
-      }) List<Trace> getTracesByIds(
+      exception = @ThriftException(type = QueryException.class, id = 1)
+  )
+  List<Trace> getTracesByIds(
       @ThriftField(value = 1) List<Long> traceIds,
       @ThriftField(value = 3) boolean adjustClockSkew
   ) throws QueryException;
 
-  @ThriftMethod(value = "getServiceNames",
-      exception = {
-          @ThriftException(type = QueryException.class, id = 1)
-      }) Set<String> getServiceNames() throws QueryException;
+  @ThriftMethod(
+      value = "getServiceNames",
+      exception = @ThriftException(type = QueryException.class, id = 1)
+  )
+  Set<String> getServiceNames() throws QueryException;
 
-  @ThriftMethod(value = "getSpanNames",
-      exception = {
-          @ThriftException(type = QueryException.class, id = 1)
-      }) Set<String> getSpanNames(
-      @ThriftField(value = 1) String serviceName
-  ) throws QueryException;
+  @ThriftMethod(
+      value = "getSpanNames",
+      exception = @ThriftException(type = QueryException.class, id = 1)
+  )
+  Set<String> getSpanNames(@ThriftField(value = 1) String serviceName) throws QueryException;
 }

--- a/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/InMemoryScalaSpanStoreTest.java
+++ b/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/InMemoryScalaSpanStoreTest.java
@@ -11,20 +11,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
-import io.zipkin.Span;
-import java.util.List;
+import com.twitter.zipkin.storage.SpanStore;
+import com.twitter.zipkin.storage.SpanStoreSpec;
 
-public class InMemoryZipkinQueryTest extends ZipkinQueryTest {
-  InMemoryZipkinQuery query = new InMemoryZipkinQuery();
+public class InMemoryScalaSpanStoreTest extends SpanStoreSpec {
+  private ScalaSpanStoreAdapter mem;
 
-  @Override protected ZipkinQuery query() {
-    return query;
+  public SpanStore store() {
+    return mem;
   }
 
-  @Override protected void reload(List<Span> spans) {
-    query.clear();
-    query.accept(spans);
+  public void clear() {
+    mem = new ScalaSpanStoreAdapter(new InMemorySpanStore());
   }
 }

--- a/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/InMemorySpanStoreTest.java
+++ b/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/InMemorySpanStoreTest.java
@@ -11,19 +11,20 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
-import com.twitter.zipkin.storage.SpanStore;
-import com.twitter.zipkin.storage.SpanStoreSpec;
+import io.zipkin.Span;
+import java.util.List;
 
-public class InMemoryZipkinQuerySpanStoreTest extends SpanStoreSpec {
-  private ZipkinQuerySpanStoreAdapter<InMemoryZipkinQuery> mem;
+public class InMemorySpanStoreTest extends SpanStoreTest {
+  InMemorySpanStore query = new InMemorySpanStore();
 
-  public SpanStore store() {
-    return mem;
+  @Override protected SpanStore query() {
+    return query;
   }
 
-  public void clear() {
-    mem = new ZipkinQuerySpanStoreAdapter<>(new InMemoryZipkinQuery());
+  @Override protected void reload(List<Span> spans) {
+    query.clear();
+    query.accept(spans);
   }
 }

--- a/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/SpanStoreTest.java
+++ b/zipkin-java-spanstore/src/test/java/io/zipkin/spanstore/SpanStoreTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.query;
+package io.zipkin.spanstore;
 
 import io.zipkin.Annotation;
 import io.zipkin.BinaryAnnotation;
@@ -36,11 +36,11 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class ZipkinQueryTest {
+public abstract class SpanStoreTest {
 
   private final Charset UTF_8 = Charset.forName("UTF-8");
 
-  protected abstract ZipkinQuery query();
+  protected abstract SpanStore query();
 
   protected abstract void reload(List<Span> spans);
 


### PR DESCRIPTION
This replaces `ZipkinQuery & Consumer<List<Span>>` with `SpanStore`,
simplifying type signatures and exposing the storage layer in its
entirety.

In the scala project, there's a SpanStore contract, a read/write api
similar to a union of the Scribe and ZipkinQuery interfaces. The java
project expects scribe to fade into an implementation detail. However,
there's still value in encapsulating the storage aspect, including
writes, as that's how we can eventually replace the storage layer in
any listener. It also helps us to write tests.

The down-side is that in many cases, the code to store is far simpler
than the code to query. Joining the two apis means you need to bring
along both when you want either. I consider this a minor concern, as
the code is still reasonably small and would have the same dependencies
either way.