### PR TITLE
Adds on-demand dependencies support to zipkin-jdbc

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/Codec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Codec.java
@@ -33,6 +33,14 @@ public interface Codec {
   @Nullable
   byte[] writeSpan(Span value);
 
+  /** Returns null if the dependency link couldn't be decoded */
+  @Nullable
+  DependencyLink readDependencyLink(byte[] bytes);
+
+  /** Returns null if the dependency link couldn't be encoded */
+  @Nullable
+  byte[] writeDependencyLink(DependencyLink value);
+
   /** Returns null if the dependencies couldn't be decoded */
   @Nullable
   Dependencies readDependencies(byte[] bytes);

--- a/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
@@ -13,6 +13,7 @@
  */
 package io.zipkin;
 
+import io.zipkin.internal.Nullable;
 import java.io.Closeable;
 import java.util.List;
 
@@ -23,13 +24,45 @@ public interface SpanStore extends Closeable {
    */
   void accept(List<Span> spans);
 
+  /**
+   * Get the available trace information from the storage system. Spans in trace are sorted by the
+   * first annotation timestamp in that span. First event should be first in the spans list.
+   *
+   * <p/> Results are sorted in order of the first span's timestamp, and contain up to
+   * {@link QueryRequest#limit} elements.
+   */
   List<List<Span>> getTraces(QueryRequest request);
 
+  /**
+   * Get the available trace information from the storage system. Spans in trace are sorted by the
+   * first annotation timestamp in that span. First event should be first in the spans list.
+   *
+   * <p/> Results are sorted in order of the first span's timestamp, and contain less elements than
+   * trace IDs when corresponding traces aren't available.
+   */
   List<List<Span>> getTracesByIds(List<Long> traceIds);
 
+  /**
+   * Get all the {@link Endpoint#serviceName service names}.
+   *
+   * <p/> Results are sorted lexicographically
+   */
   List<String> getServiceNames();
 
+  /**
+   * Get all the span names for a particular {@link Endpoint#serviceName}.
+   *
+   * <p/> Results are sorted lexicographically
+   */
   List<String> getSpanNames(String serviceName);
+
+  /**
+   * @param startTs microseconds from epoch, defaults to one day before end_time
+   * @param endTs microseconds from epoch, defaults to now
+   * @return dependency links in an interval contained by startTs and endTs, or {@link
+   * Dependencies#ZERO} if none are found
+   */
+  Dependencies getDependencies(@Nullable Long startTs, @Nullable Long endTs);
 
   @Override
   void close();

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/Pair.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/Pair.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.internal;
+
+import static io.zipkin.internal.Util.checkNotNull;
+
+/** Aids in converging streams which have 2-tuples, such as start/endTs and parent/spanId */
+public final class Pair<T> {
+
+  public static <T> Pair<T> create(T _1, T _2) {
+    return new Pair<>(_1, _2);
+  }
+
+  public final T _1;
+  public final T _2;
+
+  private Pair(T _1, T _2) {
+    this._1 = checkNotNull(_1, "_1");
+    this._2 = checkNotNull(_2, "_2");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof Pair) {
+      Pair that = (Pair) o;
+      return this._1.equals(that._1) && this._2.equals(that._2);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= this._1.hashCode();
+    h *= 1000003;
+    h ^= this._2.hashCode();
+    return h;
+  }
+}

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/ThriftCodec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/ThriftCodec.java
@@ -501,6 +501,16 @@ public final class ThriftCodec implements Codec {
     }
   }
 
+  @Override
+  public DependencyLink readDependencyLink(byte[] bytes) {
+    return read(DependencyLinkAdapter.INSTANCE, bytes);
+  }
+
+  @Override
+  public byte[] writeDependencyLink(DependencyLink value) {
+    return write(DependencyLinkAdapter.INSTANCE, value);
+  }
+
   enum DependenciesAdapter implements ThriftAdapter<Dependencies> {
     INSTANCE;
 

--- a/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
@@ -54,9 +54,21 @@ public abstract class CodecTest {
   Dependencies dependencies = new Dependencies(0L, TimeUnit.HOURS.toMicros(1), asList(
       new DependencyLink("Gizmoduck", "tflock", 4),
       new DependencyLink("mobileweb", "Gizmoduck", 4),
-      new DependencyLink("tfe", "mobileweb", 2),
-      new DependencyLink("tfe", "mobileweb", 4)
+      new DependencyLink("tfe", "mobileweb", 6)
   ));
+
+  @Test
+  public void dependencyLinkRoundTrip() throws IOException {
+    byte[] bytes = codec().writeDependencyLink(dependencies.links.get(0));
+    assertThat(codec().readDependencyLink(bytes))
+        .isEqualTo(dependencies.links.get(0));
+  }
+
+  @Test
+  public void dependencyLinkDecodesToNullOnEmpty() throws IOException {
+    assertThat(codec().readDependencyLink(new byte[0]))
+        .isNull();
+  }
 
   @Test
   public void dependenciesRoundTrip() throws IOException {

--- a/zipkin-java-core/src/test/java/io/zipkin/DependenciesTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/DependenciesTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin;
+
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependenciesTest {
+
+  DependencyLink dl1 = new DependencyLink("Gizmoduck", "tflock", 4);
+  DependencyLink dl2 = new DependencyLink("mobileweb", "Gizmoduck", 4);
+  DependencyLink dl3 = new DependencyLink("tfe", "mobileweb", 2);
+  DependencyLink dl4 = new DependencyLink("tfe", "mobileweb", 4);
+
+  Dependencies deps1 = new Dependencies(0L, MICROSECONDS.convert(1, HOURS), asList(dl1, dl3));
+  Dependencies deps2 = new Dependencies(MICROSECONDS.convert(1, HOURS), MICROSECONDS.convert(2, HOURS), asList(dl2, dl4));
+
+  @Test
+  public void identityOnDependenciesZERO() {
+    assertThat(deps1.merge(Dependencies.ZERO))
+        .isEqualTo(deps1);
+    assertThat(Dependencies.ZERO.merge(deps1))
+        .isEqualTo(deps1);
+  }
+
+  @Test
+  public void sumsWhereParentChildMatch() {
+    Dependencies result = deps1.merge(deps2);
+    assertThat(result.startTs).isEqualTo(deps1.startTs);
+    assertThat(result.endTs).isEqualTo(deps2.endTs);
+    assertThat(result.links).containsOnly(
+        dl1,
+        dl2,
+        new DependencyLink(dl3.parent, dl3.child, dl3.callCount + dl4.callCount)
+    );
+  }
+}

--- a/zipkin-java-interop/src/test/java/io/zipkin/jdbc/JDBCScalaSpanStoreTest.java
+++ b/zipkin-java-interop/src/test/java/io/zipkin/jdbc/JDBCScalaSpanStoreTest.java
@@ -15,9 +15,19 @@ package io.zipkin.jdbc;
 
 import com.twitter.zipkin.storage.SpanStore;
 import com.twitter.zipkin.storage.SpanStoreSpec;
+import io.zipkin.Annotation;
+import io.zipkin.Constants;
+import io.zipkin.DependencyLink;
+import io.zipkin.Endpoint;
+import io.zipkin.Span;
 import io.zipkin.interop.ScalaSpanStoreAdapter;
 import java.sql.SQLException;
+import java.util.List;
 import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JDBCScalaSpanStoreTest extends SpanStoreSpec {
   private static JDBCSpanStore spanStore;
@@ -37,5 +47,84 @@ public class JDBCScalaSpanStoreTest extends SpanStoreSpec {
     } catch (SQLException e) {
       throw new AssertionError(e);
     }
+  }
+
+  long traceId = -692101025335252320L;
+  long callQuery = -7842865617155193778L;
+  long dbQuery = 8207293009014896295L;
+  Endpoint zipkinWeb = Endpoint.create("zipkin-web", 172 << 24 | 17 << 16 | 3, (short) 8080);
+  Endpoint zipkinQuery = Endpoint.create("zipkin-query", 172 << 24 | 17 << 16 | 2, (short) 9411);
+  Endpoint zipkinJdbc = Endpoint.create("zipkin-jdbc", 172 << 24 | 17 << 16 | 2, 0);
+
+  List<Span> trace = asList(
+      new Span.Builder()
+          .traceId(traceId)
+          .name("GET")
+          .id(traceId)
+          .addAnnotation(Annotation.create(1444438900939000L, Constants.SERVER_RECV, zipkinWeb))
+          .addAnnotation(Annotation.create(1444438901315000L, Constants.SERVER_SEND, zipkinWeb))
+          .build(),
+      new Span.Builder()
+          .traceId(traceId)
+          .name("GET")
+          .id(callQuery)
+          .parentId(traceId)
+          .addAnnotation(Annotation.create(1444438900941000L, Constants.CLIENT_SEND, Endpoint.create("zipkin-query", 127 << 24 | 1, 0)))
+          .addAnnotation(Annotation.create(1444438900947000L, Constants.SERVER_RECV, zipkinQuery))
+          .addAnnotation(Annotation.create(1444438901017000L, Constants.SERVER_SEND, zipkinQuery))
+          .addAnnotation(Annotation.create(1444438901018000L, Constants.CLIENT_RECV, Endpoint.create("zipkin-query", 127 << 24 | 1, 0)))
+          .build(),
+      new Span.Builder()
+          .traceId(traceId)
+          .name("query")
+          .id(dbQuery)
+          .parentId(callQuery)
+          .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, zipkinJdbc))
+          .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, zipkinJdbc))
+          .build()
+  );
+
+  /**
+   * Normally, the root-span is where trace id == span id and parent id == null
+   */
+  @Test
+  public void dependencies() {
+    spanStore.accept(trace);
+
+    assertThat(spanStore.getDependencies(null, trace.get(0).endTs()).links).containsOnly(
+        new DependencyLink.Builder().parent("zipkin-web").child("zipkin-query").callCount(1).build(),
+        new DependencyLink.Builder().parent("zipkin-query").child("zipkin-jdbc").callCount(1).build()
+    );
+  }
+
+  @Test
+  public void dependencies_loopback() {
+    spanStore.accept(asList(trace.get(0), new Span.Builder()
+        .traceId(traceId)
+        .name("GET")
+        .id(callQuery)
+        .parentId(traceId)
+        .addAnnotation(Annotation.create(1444438900941000L, Constants.CLIENT_SEND, Endpoint.create("zipkin-web", 127 << 24 | 1, 0)))
+        .addAnnotation(Annotation.create(1444438900947000L, Constants.SERVER_RECV, zipkinWeb))
+        .addAnnotation(Annotation.create(1444438901017000L, Constants.SERVER_SEND, zipkinWeb))
+        .addAnnotation(Annotation.create(1444438901018000L, Constants.CLIENT_RECV, Endpoint.create("zipkin-web", 127 << 24 | 1, 0)))
+        .build()));
+
+    assertThat(spanStore.getDependencies(null, trace.get(0).endTs()).links).containsOnly(
+        new DependencyLink.Builder().parent("zipkin-web").child("zipkin-web").callCount(1).build()
+    );
+  }
+
+  /**
+   * Some systems log a different trace id than the root span. This seems "headless", as we won't
+   * see a span whose id is the same as the trace id.
+   */
+  @Test
+  public void dependencies_headlessTrace() {
+    spanStore.accept(asList(trace.get(1), trace.get(2)));
+
+    assertThat(spanStore.getDependencies(null, trace.get(0).endTs()).links).containsOnly(
+        new DependencyLink.Builder().parent("zipkin-query").child("zipkin-jdbc").callCount(1).build()
+    );
   }
 }

--- a/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
@@ -13,6 +13,12 @@
  */
 package io.zipkin.server;
 
+import io.zipkin.BinaryAnnotation;
+import io.zipkin.Dependencies;
+import io.zipkin.QueryRequest;
+import io.zipkin.Span;
+import io.zipkin.SpanStore;
+import io.zipkin.internal.Nullable;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,11 +32,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.zipkin.BinaryAnnotation;
-import io.zipkin.QueryRequest;
-import io.zipkin.Span;
-import io.zipkin.SpanStore;
 
 import static io.zipkin.internal.Util.merge;
 import static io.zipkin.internal.Util.sortedList;
@@ -91,6 +92,11 @@ public final class InMemorySpanStore implements SpanStore {
   public synchronized List<String> getSpanNames(String service) {
     if (service == null) return Collections.emptyList();
     return sortedList(serviceToSpanNames.get(service));
+  }
+
+  @Override
+  public Dependencies getDependencies(@Nullable Long startTs, @Nullable Long endTs) {
+    return Dependencies.ZERO;
   }
 
   @Override


### PR DESCRIPTION
This allows you to see the dependency-graph without hadoop or otherwise.

This shows services which are linked by parentId, with a count of how
many spans were logged. This will only show traces with at least one
edge (child), even if that edge is a loopback.

The UI remains unchanged: the point of the line corresponds with the amount of traffic.

![screen shot 2015-10-09 at 10 00 33 pm](https://cloud.githubusercontent.com/assets/64215/10409351/3f138f2e-6ed1-11e5-8a30-7848de391b77.png)