### PR TITLE
Prototype Brave SpanCollector using SpanStore

### DIFF
--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/ApiTracerConfiguration.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/ApiTracerConfiguration.java
@@ -11,8 +11,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-// TODO: switch package back after https://github.com/openzipkin/brave/pull/99
 package io.zipkin.server.brave;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerRequestInterceptor;
@@ -20,16 +24,12 @@ import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.ServerTracer;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.spring.ServletHandlerInterceptor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @Configuration
 public class ApiTracerConfiguration extends WebMvcConfigurerAdapter {
 
   @Autowired
-  Brave brave;
+  private Brave brave;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.server.brave;
+
+import java.io.Flushable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.github.kristofa.brave.SpanCollector;
+import com.twitter.zipkin.gen.AnnotationType;
+
+import io.zipkin.Annotation;
+import io.zipkin.BinaryAnnotation;
+import io.zipkin.BinaryAnnotation.Type;
+import io.zipkin.Endpoint;
+import io.zipkin.Span;
+import io.zipkin.SpanStore;
+
+/**
+ * A Brave {@link SpanCollector} that forwards to the local {@link SpanStore}.
+ *
+ */
+public class SpanStoreSpanCollector implements SpanCollector, Flushable {
+  private SpanStore spanStore;
+  private BlockingQueue<com.twitter.zipkin.gen.Span> queue = new LinkedBlockingQueue<>();
+  private int limit = 200;
+
+  public SpanStoreSpanCollector(SpanStore spanStore) {
+    this.spanStore = spanStore;
+  }
+
+  @Override
+  public void collect(com.twitter.zipkin.gen.Span span) {
+    queue.offer(span);
+    if (queue.size() >= limit) {
+      flush();
+    }
+  }
+
+  @Override
+  public void flush() {
+    List<Span> spans = new ArrayList<>(queue.size());
+    while (!queue.isEmpty()) {
+      com.twitter.zipkin.gen.Span span = queue.poll();
+      if (span != null) {
+        spans.add(convert(span));
+      }
+    }
+    this.spanStore.accept(spans);
+  }
+
+  private Span convert(com.twitter.zipkin.gen.Span span) {
+    Span.Builder builder = new Span.Builder();
+    long parent = span.getParent_id();
+    builder.name(span.getName()).id(span.getId()).parentId(parent == 0 ? null : parent)
+        .traceId(span.getTrace_id()).debug(span.isDebug());
+    List<com.twitter.zipkin.gen.Annotation> annotations = span.getAnnotations();
+    if (annotations != null) {
+      for (com.twitter.zipkin.gen.Annotation annotation : annotations) {
+        builder.addAnnotation(convert(annotation));
+      }
+    }
+    List<com.twitter.zipkin.gen.BinaryAnnotation> binaries = span.getBinary_annotations();
+    if (binaries != null) {
+      for (com.twitter.zipkin.gen.BinaryAnnotation annotation : binaries) {
+        builder.addBinaryAnnotation(convert(annotation));
+      }
+    }
+    return builder.build();
+  }
+
+  private BinaryAnnotation convert(com.twitter.zipkin.gen.BinaryAnnotation annotation) {
+    return new BinaryAnnotation.Builder().endpoint(getEndpoint(annotation.getHost()))
+        .key(annotation.getKey()).value(annotation.getValue())
+        .type(convert(annotation.getAnnotation_type())).build();
+  }
+
+  private Type convert(AnnotationType type) {
+    switch (type) {
+    case STRING:
+      return Type.STRING;
+    case DOUBLE:
+      return Type.DOUBLE;
+    case BOOL:
+      return Type.BOOL;
+    case I16:
+      return Type.I16;
+    case I32:
+      return Type.I32;
+    case I64:
+      return Type.I64;
+    default:
+      return Type.BYTES;
+    }
+  }
+
+  private Endpoint getEndpoint(com.twitter.zipkin.gen.Endpoint endpoint) {
+    return new Endpoint.Builder().serviceName(endpoint.getService_name())
+        .port(endpoint.getPort()).ipv4(endpoint.getIpv4()).build();
+  }
+
+  private Annotation convert(com.twitter.zipkin.gen.Annotation annotation) {
+    return new Annotation.Builder().endpoint(getEndpoint(annotation.getHost()))
+        .timestamp(annotation.getTimestamp()).value(annotation.getValue()).build();
+  }
+
+  @Override
+  public void addDefaultAnnotation(String key, String value) {
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/zipkin-java-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-java-server/src/main/resources/zipkin-server.yml
@@ -18,6 +18,7 @@ server:
 spring:
   datasource:
     driver-class-name: com.mysql.jdbc.Driver
+# add this for mysql tracing: &statementInterceptors=com.github.kristofa.brave.mysql.MySQLStatementInterceptor
     url: jdbc:mysql://${mysql.host}:${mysql.port}/${mysql.db}?autoReconnect=true
     username: ${mysql.username}
     password: ${mysql.password}

--- a/zipkin-java-server/src/test/java/io/zipkin/server/brave/SpanStoreSpanCollectorTest.java
+++ b/zipkin-java-server/src/test/java/io/zipkin/server/brave/SpanStoreSpanCollectorTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.server.brave;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+
+import io.zipkin.server.InMemorySpanStore;
+
+public class SpanStoreSpanCollectorTest {
+
+  private InMemorySpanStore spanStore = new InMemorySpanStore();
+  private SpanStoreSpanCollector collector = new SpanStoreSpanCollector(spanStore);
+
+  @Test
+  public void addOne() {
+    Span span = getSpan(1234L, 1234L, "foo", "service", "value");
+    collector.collect(span);
+    collector.flush();
+    assertEquals("[service]", spanStore.getServiceNames().toString());
+  }
+
+  @Test
+  public void addMany() {
+    for (int i = 0; i < 500; i++) {
+      Span span = getSpan(1234L + i, 1234L, "foo", "service", "value");
+      collector.collect(span);
+    }
+    collector.flush();
+    assertEquals("[service]", spanStore.getServiceNames().toString());
+    assertEquals(500, spanStore.getTracesByIds(Arrays.asList(1234L)).get(0).size());
+  }
+
+  private Span getSpan(long id, long traceId, String name, String service, String value) {
+    Span span = new Span();
+    span.setId(id);
+    span.setTrace_id(traceId);
+    span.setName(name);
+    Annotation annotation = new Annotation();
+    annotation.setHost(new Endpoint(0, (short) 80, service));
+    annotation.setValue(value);
+    span.addToAnnotations(annotation);
+    return span;
+  }
+
+}


### PR DESCRIPTION
With this change the thrift server is not used by Brave (it sends spans directly top the span store). This only affects the tracing of the requests to the query service.