### PR TITLE
Adds span list codec for json and thrift

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/Codec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Codec.java
@@ -16,6 +16,7 @@ package io.zipkin;
 import io.zipkin.internal.JsonCodec;
 import io.zipkin.internal.Nullable;
 import io.zipkin.internal.ThriftCodec;
+import java.util.List;
 
 /**
  * Methods make an attempt to perform codec operations, failing to null.
@@ -32,6 +33,14 @@ public interface Codec {
   /** Returns null if the span couldn't be encoded */
   @Nullable
   byte[] writeSpan(Span value);
+
+  /** Returns null if the spans couldn't be decoded */
+  @Nullable
+  List<Span> readSpans(byte[] bytes);
+
+  /** Returns null if the span couldn't be encoded */
+  @Nullable
+  byte[] writeSpans(List<Span> value);
 
   /** Returns null if the dependency link couldn't be decoded */
   @Nullable

--- a/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
@@ -38,6 +38,19 @@ public abstract class CodecTest {
   }
 
   @Test
+  public void spansRoundTrip() throws IOException {
+    byte[] bytes = codec().writeSpans(TestObjects.TRACE);
+    assertThat(codec().readSpans(bytes))
+        .isEqualTo(TestObjects.TRACE);
+  }
+
+  @Test
+  public void spansDecodeToNullOnEmpty() throws IOException {
+    assertThat(codec().readSpans(new byte[0]))
+        .isNull();
+  }
+
+  @Test
   public void dependencyLinkRoundTrip() throws IOException {
     DependencyLink link = DependencyLink.create("tfe", "mobileweb", 6);
     byte[] bytes = codec().writeDependencyLink(link);

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinQueryApiV1.java
@@ -46,8 +46,7 @@ import okio.Buffer;
 @RequestMapping("/api/v1")
 public class ZipkinQueryApiV1 {
 
-  static final Serializer<List<Span>> TRACE_TO_JSON = writeJsonList(Codec.JSON::writeSpan);
-  static final Serializer<List<List<Span>>> TRACES_TO_JSON = writeJsonList(TRACE_TO_JSON);
+  static final Serializer<List<List<Span>>> TRACES_TO_JSON = writeJsonList(Codec.JSON::writeSpans);
   static final Serializer<List<DependencyLink>> DEPENDENCY_LINKS_TO_JSON = writeJsonList(Codec.JSON::writeDependencyLink);
 
   @Autowired
@@ -105,7 +104,7 @@ public class ZipkinQueryApiV1 {
     if (traces.isEmpty()) {
       throw new TraceNotFoundException(traceId, id);
     }
-    return TRACE_TO_JSON.apply(traces.get(0));
+    return Codec.JSON.writeSpans(traces.get(0));
   }
 
   @ExceptionHandler(TraceNotFoundException.class)


### PR DESCRIPTION
This moves codec of `List<Span>` to a top-level type in preparation of a
POST endpoint that accepts either in thrift or json.