### PR TITLE
Unzips all jar and removes actuator, reducing bootstrap time

### DIFF
--- a/zipkin-java-server/Dockerfile
+++ b/zipkin-java-server/Dockerfile
@@ -20,8 +20,8 @@ VOLUME /tmp
 
 ADD target/zipkin-java-server-0.1.0-SNAPSHOT-exec.jar zipkin-server.jar
 
-RUN touch zipkin-server.jar
+RUN unzip zipkin-server.jar
 
 EXPOSE 9411
 
-CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java -Djava.security.egd=file:/dev/./urandom -jar zipkin-server.jar
+CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java -Djava.security.egd=file:/dev/./urandom -cp '.:lib/*' io.zipkin.server.ZipkinServer

--- a/zipkin-java-server/pom.xml
+++ b/zipkin-java-server/pom.xml
@@ -69,12 +69,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
With a default docker-machine on a Mid-2014 Macbook Pro, and the default
docker-compose file. I was getting consistent 16s startup, as reported
by Spring Boot's output.

My suspicion was that this was packaging related, as there are many jars
inside the default assembly of Spring Boot. Since Boot does classpath
scanning, it would need to unpack these in order to progress.

@dsyer found that if we do the unpacking at install time, we can reduce
the impact. I verified this, by running the same operation. I'm now
getting consistent 14s ranges on the same docker-machine.

There's other optimizations left. For example, if you remove the
database property and delete the Hikari dep from the pom (so that boot
can't find it), another 2-3 seconds are saved in an otherwise identical
docker-machine.

Regardless, I'm glad to have a couple seconds off without changing
functionality. This change does that.