### PR TITLE
Updates to upstream 1.19.1, eliminating the collector dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,20 +13,9 @@
 #
 
 mysql:
-  image: openzipkin/zipkin-mysql:1.18.0
+  image: openzipkin/zipkin-mysql:1.19.1
   ports:
     - 3306:3306
-collector:
-  image: openzipkin/zipkin-collector:1.18.0
-  environment:
-    - TRANSPORT_TYPE=scribe
-    - STORAGE_TYPE=mysql
-  expose:
-    - 9410
-  ports:
-    - 9410:9410
-  links:
-    - mysql:storage
 query:
   build: zipkin-java-server
   environment:
@@ -38,11 +27,11 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.18.0
+  image: openzipkin/zipkin-web:1.19.1
   ports:
     - 8080:8080
   environment:
-    - TRANSPORT_TYPE=scribe
+    - TRANSPORT_TYPE=http
+    - WEB_LOG_LEVEL=DEBUG
   links:
-    - collector
     - query

--- a/zipkin-java-interop/pom.xml
+++ b/zipkin-java-interop/pom.xml
@@ -31,17 +31,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <zipkin-scala.version>1.18.1</zipkin-scala.version>
+    <zipkin-scala.version>1.19.1</zipkin-scala.version>
     <scalatest.version>2.2.5</scalatest.version>
   </properties>
-
-  <!-- Temporary until 1.18.2 -->
-  <repositories>
-    <repository>
-      <id>jfrog-snapshot</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>
@@ -72,8 +64,7 @@
       <groupId>io.zipkin</groupId>
       <artifactId>zipkin-common</artifactId>
       <classifier>test</classifier>
-      <!-- TODO revert to ${zipkin-scala.version} on 1.18.2 -->
-      <version>1.18.2-SNAPSHOT</version>
+      <version>${zipkin-scala.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin-java-server/Dockerfile
+++ b/zipkin-java-server/Dockerfile
@@ -12,7 +12,7 @@
 # the License.
 #
 
-FROM openzipkin/zipkin-base:base-1.18.1
+FROM openzipkin/zipkin-base:base-1.19.1
 
 MAINTAINER OpenZipkin "http://zipkin.io/"
 


### PR DESCRIPTION
Starting with zipkin 1.19.1, the UI process (zipkin-web) no longer
depends on scribe for self-tracing. This cuts the minimum deployment to
2 processes, which happen to be the smallest.

The net effect is a simpler starter architecture, which takes less time
to understand, less MB to download, and less memory to run.