### PR TITLE
Updates to Spring Boot 1.3 and upstream 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # zipkin-java
 Experimental java zipkin backend. Please look at issues as we are currently working on scope.
 
+## Server
+You can run the experimental server to power the zipkin web UI.
 
-## Docker
-You can run the experimental docker server to power the zipkin web UI. The following is a hack of the [docker-zipkin](https://github.com/openzipkin/docker-zipkin) docker-compose instructions.
+```bash
+$ (cd zipkin-java-server; mvn spring-boot:run)
+```
+
+### Docker  
+You can also run the java server with docker. The following is a hack of the [docker-zipkin](https://github.com/openzipkin/docker-zipkin) docker-compose instructions.
 
 ```bash
 # build zipkin-java-server/target/zipkin-java-server-0.1.0-SNAPSHOT.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@
 #
 
 mysql:
-  image: openzipkin/zipkin-mysql:1.21.1
+  image: openzipkin/zipkin-mysql:1.25.0
   ports:
     - 3306:3306
 query:
@@ -27,7 +27,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.21.1
+  image: openzipkin/zipkin-web:1.25.0
   ports:
     - 8080:8080
   environment:

--- a/pom.xml
+++ b/pom.xml
@@ -54,13 +54,13 @@
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <maven-license-plugin.version>2.11</maven-license-plugin.version>
     <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
-    <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-    <maven-shade-plugin.version>2.4.1</maven-shade-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <moshi.version>1.0.0</moshi.version>
     <okio.version>1.6.0</okio.version>
-    <spring-boot.version>1.2.7.RELEASE</spring-boot.version>
+    <spring-boot.version>1.3.0.RELEASE</spring-boot.version>
     <libthrift.version>0.9.3</libthrift.version>
   </properties>
 
@@ -187,6 +187,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/zipkin-java-core/src/main/java/io/zipkin/Constants.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Constants.java
@@ -14,21 +14,140 @@
 package io.zipkin;
 
 public final class Constants {
-  /* Common annotation values */
-  public static final String CLIENT_RECV = "cr";
+  /**
+   * The client sent ("cs") a request to a server. There is only one send per span. For example, if
+   * there's a transport error, each attempt can be logged as a {@link #WIRE_SEND} annotation.
+   *
+   * <p/>If chunking is involved, each chunk could be logged as a separate {@link
+   * #CLIENT_SEND_FRAGMENT} in the same span.
+   *
+   * <p/>{@link Annotation#endpoint} is not the server. It is the host which logged the send event,
+   * almost always the client. When logging CLIENT_SEND, instrumentation should also log the {@link
+   * #SERVER_ADDR}.
+   */
   public static final String CLIENT_SEND = "cs";
-  public static final String SERVER_RECV = "sr";
+
+  /**
+   * The client received ("cr") a response from a server. There is only one receive per span. For
+   * example, if duplicate responses were received, each can be logged as a {@link #WIRE_RECV}
+   * annotation.
+   *
+   * <p/>If chunking is involved, each chunk could be logged as a separate {@link
+   * #CLIENT_RECV_FRAGMENT} in the same span.
+   *
+   * <p/>{@link Annotation#endpoint} is not the server. It is the host which logged the receive
+   * event, almost always the client. The actual endpoint of the server is recorded separately as
+   * {@link #SERVER_ADDR} when {@link #CLIENT_SEND} is logged.
+   */
+  public static final String CLIENT_RECV = "cr";
+
+  /**
+   * The server sent ("ss") a response to a client. There is only one response per span. If there's
+   * a transport error, each attempt can be logged as a {@link #WIRE_SEND} annotation.
+   *
+   * <p/>Typically, a trace ends with a server send, so the last timestamp of a trace is often the
+   * timestamp of the root span's server send.
+   *
+   * <p/>If chunking is involved, each chunk could be logged as a separate {@link
+   * #SERVER_SEND_FRAGMENT} in the same span.
+   *
+   * <p/>{@link Annotation#endpoint} is not the client. It is the host which logged the send event,
+   * almost always the server. The actual endpoint of the client is recorded separately as {@link
+   * #CLIENT_ADDR} when {@link #SERVER_RECV} is logged.
+   */
   public static final String SERVER_SEND = "ss";
 
   /**
-   * The endpoint associated with "CLIENT_" annotations is not necessarily {@link
-   * Annotation#endpoint}
+   * The server received ("sr") a request from a client. There is only one request per span.  For
+   * example, if duplicate responses were received, each can be logged as a {@link #WIRE_RECV}
+   * annotation.
+   *
+   * <p/>Typically, a trace starts with a server receive, so the first timestamp of a trace is often
+   * the timestamp of the root span's server receive.
+   *
+   * <p/>If chunking is involved, each chunk could be logged as a separate {@link
+   * #SERVER_RECV_FRAGMENT} in the same span.
+   *
+   * <p/>{@link Annotation#endpoint} is not the client. It is the host which logged the receive
+   * event, almost always the server. When logging SERVER_RECV, instrumentation should also log the
+   * {@link #CLIENT_ADDR}.
+   */
+  public static final String SERVER_RECV = "sr";
+
+  /**
+   * Optionally logs an attempt to send a message on the wire. Multiple wire send events could
+   * indicate network retries. A lag between client or server send and wire send might indicate
+   * queuing or processing delay.
+   */
+  public static final String WIRE_SEND = "ws";
+
+  /**
+   * Optionally logs an attempt to receive a message from the wire. Multiple wire receive events
+   * could indicate network retries. A lag between wire receive and client or server receive might
+   * indicate queuing or processing delay.
+   */
+  public static final String WIRE_RECV = "wr";
+
+  /**
+   * Optionally logs progress of a ({@linkplain #CLIENT_SEND}, {@linkplain #WIRE_SEND}). For
+   * example, this could be one chunk in a chunked request.
+   */
+  public static final String CLIENT_SEND_FRAGMENT = "csf";
+
+  /**
+   * Optionally logs progress of a ({@linkplain #CLIENT_RECV}, {@linkplain #WIRE_RECV}). For
+   * example, this could be one chunk in a chunked response.
+   */
+  public static final String CLIENT_RECV_FRAGMENT = "crf";
+
+  /**
+   * Optionally logs progress of a ({@linkplain #SERVER_SEND}, {@linkplain #WIRE_SEND}). For
+   * example, this could be one chunk in a chunked response.
+   */
+  public static final String SERVER_SEND_FRAGMENT = "ssf";
+
+  /**
+   * Optionally logs progress of a ({@linkplain #SERVER_RECV}, {@linkplain #WIRE_RECV}). For
+   * example, this could be one chunk in a chunked request.
+   */
+  public static final String SERVER_RECV_FRAGMENT = "srf";
+
+  /**
+   * The {@link BinaryAnnotation#value value} of "lc" is the component or namespace of a local
+   * span.
+   *
+   * <p/>{@link BinaryAnnotation#endpoint} adds service context needed to support queries.
+   *
+   * <p/>Local Component("lc") supports three key features: flagging, query by service and filtering
+   * Span.name by namespace.
+   *
+   * <p/>While structurally the same, local spans are fundamentally different than RPC spans in how
+   * they should be interpreted. For example, zipkin v1 tools center on RPC latency and service
+   * graphs. Root local-spans are neither indicative of critical path RPC latency, nor have impact
+   * on the shape of a service graph. By flagging with "lc", tools can special-case local spans.
+   *
+   * <p/>Zipkin v1 Spans are unqueryable unless they can be indexed by service name. The only path
+   * to a {@link Endpoint#serviceName service name} is via {@link BinaryAnnotation#endpoint
+   * host}. By logging "lc", a local span can be queried even if no other annotations are logged.
+   *
+   * <p/>The value of "lc" is the namespace of {@link Span#name}. For example, it might be
+   * "finatra2", for a span named "bootstrap". "lc" allows you to resolves conflicts for the same
+   * Span.name, for example "finatra/bootstrap" vs "finch/bootstrap". Using local component, you'd
+   * search for spans named "bootstrap" where "lc=finch"
+   */
+  public static final String LOCAL_COMPONENT = "lc";
+
+  /**
+   * When present, {@link BinaryAnnotation#endpoint} indicates a client address ("ca") in a span.
+   * Most likely, there's only one. Multiple addresses are possible when a client changes its ip or
+   * port within a span.
    */
   public static final String CLIENT_ADDR = "ca";
 
   /**
-   * The endpoint associated with "SERVER_" annotations is not necessarily {@link
-   * Annotation#endpoint}
+   * When present, {@link BinaryAnnotation#endpoint} indicates a server address ("sa") in a span.
+   * Most likely, there's only one. Multiple addresses are possible when a client is redirected, or
+   * fails to a different server ip or port.
    */
   public static final String SERVER_ADDR = "sa";
 

--- a/zipkin-java-core/src/main/java/io/zipkin/Endpoint.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Endpoint.java
@@ -20,7 +20,7 @@ import java.net.InetSocketAddress;
 
 import static io.zipkin.internal.Util.checkNotNull;
 
-/** Indicates the network context of a service recording an annotation. */
+/** Indicates the network context of a service involved in a span. */
 public final class Endpoint {
 
   public static Endpoint create(String serviceName, int ipv4, int port) {
@@ -32,9 +32,16 @@ public final class Endpoint {
   }
 
   /**
-   * Service name, such as "memcache" or "zipkin-web"
+   * Classifier of a source or destination in lowercase, such as "zipkin-web".
    *
-   * <p/>Note: Some implementations set this to "Unknown" or "Unknown Service"
+   * <p/>Conventionally, when the service name isn't known, service_name = "unknown".
+   *
+   * <p/>This is the primary parameter for trace lookup, so should be intuitive as possible, for
+   * example, matching names in service discovery.
+   *
+   * <p/>Particularly clients may not have a reliable service name at ingest. One approach is to set
+   * serviceName to "unknown" at ingest, and later assign a better label based on binary
+   * annotations, such as user agent.
    */
   public final String serviceName;
 
@@ -77,16 +84,19 @@ public final class Endpoint {
       this.port = source.port;
     }
 
+    /** @see Endpoint#serviceName */
     public Builder serviceName(String serviceName) {
       this.serviceName = serviceName;
       return this;
     }
 
+    /** @see Endpoint#ipv4 */
     public Builder ipv4(int ipv4) {
       this.ipv4 = ipv4;
       return this;
     }
 
+    /** @see Endpoint#port */
     public Builder port(short port) {
       if (port != 0) {
         this.port = port;

--- a/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
@@ -57,12 +57,21 @@ public interface SpanStore extends Closeable {
   List<String> getSpanNames(String serviceName);
 
   /**
-   * @param startTs microseconds from epoch, defaults to one day before end_time
-   * @param endTs microseconds from epoch, defaults to now
-   * @return dependency links in an interval contained by startTs and endTs, or empty if none are
-   * found
+   * Returns dependency links derived from spans.
+   *
+   * <p/>Implementations may bucket aggregated data, for example daily. When this is the case, endTs
+   * may be floored to align with that bucket, for example midnight if daily. lookback applies to
+   * the original endTs, even when bucketed. Using the daily example, if endTs was 11pm and lookback
+   * was 25 hours, the implementation would query against 2 buckets.
+   *
+   * @param endTs only return links from spans where {@link Span#timestamp} are at or before this
+   *              time in epoch milliseconds.
+   * @param lookback only return links from spans where {@link Span#timestamp} are at or after
+   *                 (endTs - lookback) in milliseconds. Defaults to endTs.
+   * @return dependency links in an interval contained by (endTs - lookback) or empty if none are
+   *         found
    */
-  List<DependencyLink> getDependencies(@Nullable Long startTs, @Nullable Long endTs);
+  List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback);
 
   @Override
   void close();

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/CorrectForClockSkew.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/CorrectForClockSkew.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.internal;
+
+import io.zipkin.Annotation;
+import io.zipkin.Constants;
+import io.zipkin.Endpoint;
+import io.zipkin.Span;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Adjusts spans
+ */
+public enum CorrectForClockSkew implements Function<List<Span>, List<Span>> {
+  INSTANCE;
+
+  static class ClockSkew {
+    final Endpoint endpoint;
+    final long skew;
+
+    public ClockSkew(Endpoint endpoint, long skew) {
+      this.endpoint = endpoint;
+      this.skew = skew;
+    }
+  }
+
+  public List<Span> apply(List<Span> spans) {
+    for (Span s : spans) {
+      if (s.parentId == null) {
+        SpanNode tree = SpanNode.create(s, spans);
+        adjust(tree, null);
+        return tree.toSpans();
+      }
+    }
+    return spans;
+  }
+
+  /**
+   * Recursively adjust the timestamps on the span tree. Root span is the reference point, all
+   * children's timestamps gets adjusted based on that span's timestamps.
+   */
+  private void adjust(SpanNode node, @Nullable ClockSkew skewFromParent) {
+    // adjust skew for the endpoint brought over from the parent span
+    if (skewFromParent != null) {
+      node.span = adjustTimestamps(node.span, skewFromParent);
+    }
+
+    // Is there any skew in the current span?
+    ClockSkew skew = getClockSkew(node.span);
+    if (skew != null) {
+      // the current span's skew may be a different endpoint than skewFromParent, adjust again.
+      node.span = adjustTimestamps(node.span, skew);
+
+      // propagate skew to any children
+      for (SpanNode child : node.children) {
+        adjust(child, skew);
+      }
+    }
+  }
+
+  /** If any annotation has an IP with skew associated, adjust accordingly. */
+  private Span adjustTimestamps(Span span, ClockSkew clockSkew) {
+    List<Annotation> annotations = null;
+    for (int i = 0; i < span.annotations.size(); i++) {
+      Annotation a = span.annotations.get(i);
+      if (a.endpoint == null) continue;
+      if (clockSkew.endpoint.ipv4 == a.endpoint.ipv4) {
+        if (annotations == null) annotations = new ArrayList<>(span.annotations);
+        annotations.set(i, new Annotation.Builder(a).timestamp(a.timestamp - clockSkew.skew).build());
+      }
+    }
+    if (annotations == null) return span;
+    // reset timestamp and duration as if there's skew, these will change.
+    long first = annotations.get(0).timestamp;
+    long last = annotations.get(annotations.size() - 1).timestamp;
+    long duration = last - first;
+    return new Span.Builder(span).timestamp(first).duration(duration).annotations(annotations).build();
+  }
+
+  /** Use client/server annotations to determine if there's clock skew. */
+  @Nullable
+  private ClockSkew getClockSkew(Span span) {
+    Map<String, Annotation> annotations = asMap(span.annotations);
+
+    Long clientSend = getTimestamp(annotations, Constants.CLIENT_SEND);
+    Long clientRecv = getTimestamp(annotations, Constants.CLIENT_RECV);
+    Long serverRecv = getTimestamp(annotations, Constants.SERVER_RECV);
+    Long serverSend = getTimestamp(annotations, Constants.SERVER_SEND);
+
+    if (clientSend == null || clientRecv == null || serverRecv == null || serverSend == null) {
+      return null;
+    }
+
+    Endpoint server = annotations.get(Constants.SERVER_RECV).endpoint;
+    server = server == null ? annotations.get(Constants.SERVER_SEND).endpoint : server;
+    if (server == null) return null;
+
+    long clientDuration = clientRecv - clientSend;
+    long serverDuration = serverSend - serverRecv;
+
+    // There is only clock skew if CS is after SR or CR is before SS
+    boolean csAhead = clientSend < serverRecv;
+    boolean crAhead = clientRecv > serverSend;
+    if (serverDuration > clientDuration || (csAhead && crAhead)) {
+      return null;
+    }
+    long latency = (clientDuration - serverDuration) / 2;
+    long skew = serverRecv - latency - clientSend;
+    if (skew != 0L) {
+      return new ClockSkew(server, skew);
+    }
+    return null;
+  }
+
+  /** Get the annotations as a map with value to annotation bindings. */
+  private static Map<String, Annotation> asMap(List<Annotation> annotations) {
+    Map<String, Annotation> result = new LinkedHashMap<>(annotations.size());
+    for (Annotation a : annotations) {
+      result.put(a.value, a);
+    }
+    return result;
+  }
+
+  @Nullable
+  private Long getTimestamp(Map<String, Annotation> annotations, String value) {
+    Annotation result = annotations.get(value);
+    return result != null ? result.timestamp : null;
+  }
+}

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/JsonCodec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/JsonCodec.java
@@ -144,7 +144,7 @@ public final class JsonCodec implements Codec {
             switch (reader.peek()) {
               case BOOLEAN:
                 type = BinaryAnnotation.Type.BOOL;
-                result.value(reader.nextBoolean() ? new byte[]{0} : new byte[]{1});
+                result.value(reader.nextBoolean() ? new byte[]{1} : new byte[]{0});
                 break;
               case STRING:
                 string = reader.nextString();
@@ -260,6 +260,12 @@ public final class JsonCodec implements Codec {
           case "parentId":
             result.parentId(HEX_LONG_ADAPTER.fromJson(reader));
             break;
+          case "timestamp":
+            result.timestamp(reader.nextLong());
+            break;
+          case "duration":
+            result.duration(reader.nextLong());
+            break;
           case "annotations":
             reader.beginArray();
             while (reader.hasNext()) {
@@ -296,6 +302,12 @@ public final class JsonCodec implements Codec {
       if (value.parentId != null) {
         writer.name("parentId");
         HEX_LONG_ADAPTER.toJson(writer, value.parentId);
+      }
+      if (value.timestamp != null) {
+        writer.name("timestamp").value(value.timestamp);
+      }
+      if (value.duration != null) {
+        writer.name("duration").value(value.duration);
       }
       writer.name("annotations");
       writer.beginArray();

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/SpanNode.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/SpanNode.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.internal;
+
+import io.zipkin.Span;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static io.zipkin.internal.Util.checkNotNull;
+
+final class SpanNode {
+  /** mutable to avoid allocating lists for no reason */
+  Span span;
+  List<SpanNode> children = Collections.emptyList();
+
+  private SpanNode(Span span) {
+    this.span = checkNotNull(span, "span");
+  }
+
+  void addChild(SpanNode node) {
+    if (children.equals(Collections.emptyList())) children = new LinkedList<>();
+    children.add(node);
+  }
+
+  static SpanNode create(Span span, List<Span> spans) {
+    SpanNode rootNode = new SpanNode(span);
+
+    // Initialize nodes representing the trace tree
+    Map<Long, SpanNode> idToNode = new LinkedHashMap<>();
+    for (Span s : spans) {
+      if (s.parentId == null) continue; // special-case root
+      idToNode.put(s.id, new SpanNode(s));
+    }
+
+    // Collect the parent-child relationships between all spans.
+    Map<Long, Long> idToParent = new LinkedHashMap<>();
+    for (Map.Entry<Long, SpanNode> entry : idToNode.entrySet()) {
+      idToParent.put(entry.getKey(), entry.getValue().span.parentId);
+    }
+
+    // Materialize the tree using parent - child relationships
+    for (Map.Entry<Long, Long> entry : idToParent.entrySet()) {
+      SpanNode node = idToNode.get(entry.getKey());
+      SpanNode parent = idToNode.get(entry.getValue());
+      if (parent == null) { // attribute missing parents to root
+        rootNode.addChild(node);
+      } else {
+        parent.addChild(node);
+      }
+    }
+    return rootNode;
+  }
+
+  List<Span> toSpans() {
+    if (children.isEmpty()) {
+      return Collections.singletonList(span);
+    }
+    List<Span> result = new LinkedList<>();
+    result.add(span);
+    for (SpanNode child : children) {
+      result.addAll(child.toSpans());
+    }
+    return result;
+  }
+}

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/ThriftCodec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/ThriftCodec.java
@@ -319,6 +319,8 @@ public final class ThriftCodec implements Codec {
     private static final TField ANNOTATIONS_FIELD_DESC = new TField("annotations", TType.LIST, (short) 6);
     private static final TField BINARY_ANNOTATIONS_FIELD_DESC = new TField("binary_annotations", TType.LIST, (short) 8);
     private static final TField DEBUG_FIELD_DESC = new TField("debug", TType.BOOL, (short) 9);
+    private static final TField TIMESTAMP_FIELD_DESC = new TField("timestamp", TType.I64, (short) 10);
+    private static final TField DURATION_FIELD_DESC = new TField("duration", TType.I64, (short) 11);
 
     @Override
     public Span read(TProtocol iprot) throws TException {
@@ -388,6 +390,20 @@ public final class ThriftCodec implements Codec {
               skip(iprot, field.type);
             }
             break;
+          case 10: // TIMESTAMP
+            if (field.type == TType.I64) {
+              result.timestamp(iprot.readI64());
+            } else {
+              skip(iprot, field.type);
+            }
+            break;
+          case 11: // DURATION
+            if (field.type == TType.I64) {
+              result.duration(iprot.readI64());
+            } else {
+              skip(iprot, field.type);
+            }
+            break;
           default:
             skip(iprot, field.type);
         }
@@ -438,6 +454,18 @@ public final class ThriftCodec implements Codec {
       if (value.debug != null) {
         oprot.writeFieldBegin(DEBUG_FIELD_DESC);
         oprot.writeBool(value.debug);
+        oprot.writeFieldEnd();
+      }
+
+      if (value.timestamp != null) {
+        oprot.writeFieldBegin(TIMESTAMP_FIELD_DESC);
+        oprot.writeI64(value.timestamp);
+        oprot.writeFieldEnd();
+      }
+
+      if (value.duration != null) {
+        oprot.writeFieldBegin(DURATION_FIELD_DESC);
+        oprot.writeI64(value.duration);
         oprot.writeFieldEnd();
       }
 

--- a/zipkin-java-core/src/test/java/io/zipkin/SpanTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/SpanTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+import static io.zipkin.TestObjects.WEB_ENDPOINT;
+import static io.zipkin.assertj.ZipkinAssertions.assertThat;
+
+public class SpanTest {
+
+  @Test
+  public void spanNamesLowercase() {
+    assertThat(new Span.Builder().traceId(1L).id(1L).name("GET").build())
+        .hasName("get");
+  }
+
+  @Test
+  public void mergeWhenBinaryAnnotationsSentSeparately() {
+    Span part1 = new Span.Builder()
+        .traceId(1L)
+        .name("")
+        .id(1L)
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, WEB_ENDPOINT))
+        .build();
+
+    Span part2 = new Span.Builder()
+        .traceId(1L)
+        .name("get")
+        .id(1L)
+        .timestamp(1444438900939000L)
+        .duration(376000L)
+        .addAnnotation(Annotation.create(1444438900939000L, Constants.SERVER_RECV, WEB_ENDPOINT))
+        .addAnnotation(Annotation.create(1444438901315000L, Constants.SERVER_SEND, WEB_ENDPOINT))
+        .build();
+
+    Span expected = new Span.Builder(part2)
+        .addBinaryAnnotation(part1.binaryAnnotations.get(0))
+        .build();
+
+    assertThat(new Span.Builder(part1).merge(part2).build()).isEqualTo(expected);
+    assertThat(new Span.Builder(part2).merge(part1).build()).isEqualTo(expected);
+  }
+
+  /**
+   * Some instrumentation set name to "unknown" or empty. This ensures dummy span names lose on
+   * merge.
+   */
+  @Test
+  public void mergeOverridesDummySpanNames() {
+    for (String nonName : Arrays.asList("", "unknown")) {
+      Span unknown = new Span.Builder().traceId(1).id(2).name(nonName).build();
+      Span get = new Span.Builder(unknown).name("get").build();
+
+      assertThat(new Span.Builder(unknown).merge(get).build()).hasName("get");
+      assertThat(new Span.Builder(get).merge(unknown).build()).hasName("get");
+    }
+  }
+}

--- a/zipkin-java-core/src/test/java/io/zipkin/TestObjects.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/TestObjects.java
@@ -27,30 +27,40 @@ public final class TestObjects {
   public static final Endpoint JDBC_ENDPOINT = Endpoint.create("zipkin-jdbc", 172 << 24 | 17 << 16 | 2);
 
   public static final List<Span> TRACE = asList(
-      new Span.Builder()
+      new Span.Builder() // browser calls web
           .traceId(WEB_SPAN_ID)
-          .name("GET")
+          .name("get")
           .id(WEB_SPAN_ID)
+          .timestamp(1444438900939000L)
+          .duration(376000L)
           .addAnnotation(Annotation.create(1444438900939000L, Constants.SERVER_RECV, WEB_ENDPOINT))
           .addAnnotation(Annotation.create(1444438901315000L, Constants.SERVER_SEND, WEB_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, WEB_ENDPOINT))
           .build(),
-      new Span.Builder()
+      new Span.Builder() // web calls query
           .traceId(WEB_SPAN_ID)
-          .name("GET")
+          .name("get")
           .id(QUERY_SPAN_ID)
           .parentId(WEB_SPAN_ID)
-          .addAnnotation(Annotation.create(1444438900941000L, Constants.CLIENT_SEND, Endpoint.create("zipkin-query", 127 << 24 | 1)))
+          .timestamp(1444438900941000L)
+          .duration(77000L)
+          .addAnnotation(Annotation.create(1444438900941000L, Constants.CLIENT_SEND, WEB_ENDPOINT))
           .addAnnotation(Annotation.create(1444438900947000L, Constants.SERVER_RECV, QUERY_ENDPOINT))
           .addAnnotation(Annotation.create(1444438901017000L, Constants.SERVER_SEND, QUERY_ENDPOINT))
-          .addAnnotation(Annotation.create(1444438901018000L, Constants.CLIENT_RECV, Endpoint.create("zipkin-query", 127 << 24 | 1)))
+          .addAnnotation(Annotation.create(1444438901018000L, Constants.CLIENT_RECV, WEB_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, QUERY_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.address(Constants.CLIENT_ADDR, WEB_ENDPOINT))
           .build(),
-      new Span.Builder()
+      new Span.Builder() // query calls jdbc
           .traceId(WEB_SPAN_ID)
           .name("query")
           .id(JDBC_SPAN_ID)
           .parentId(QUERY_SPAN_ID)
-          .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, JDBC_ENDPOINT))
-          .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, JDBC_ENDPOINT))
+          .timestamp(1444438900948000L)
+          .duration(31000L)
+          .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, QUERY_ENDPOINT))
+          .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, QUERY_ENDPOINT))
+          .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, JDBC_ENDPOINT))
           .build()
   );
 

--- a/zipkin-java-core/src/test/java/io/zipkin/assertj/SpanAssert.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/assertj/SpanAssert.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.assertj;
+
+import io.zipkin.BinaryAnnotation;
+import io.zipkin.Span;
+import io.zipkin.internal.Util;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.internal.ByteArrays;
+import org.assertj.core.internal.Objects;
+
+public final class SpanAssert extends AbstractAssert<SpanAssert, Span> {
+
+  ByteArrays arrays = ByteArrays.instance();
+  Objects objects = Objects.instance();
+
+  public SpanAssert(Span actual) {
+    super(actual, SpanAssert.class);
+  }
+
+  public SpanAssert hasName(String expected) {
+    isNotNull();
+    objects.assertEqual(info, actual.name, expected);
+    return this;
+  }
+
+  public SpanAssert hasTimestamp(long expected) {
+    isNotNull();
+    objects.assertEqual(info, actual.timestamp, expected);
+    return this;
+  }
+
+  public SpanAssert hasDuration(long expected) {
+    isNotNull();
+    objects.assertEqual(info, actual.duration, expected);
+    return this;
+  }
+
+  public SpanAssert hasBinaryAnnotation(String key, String utf8Expected) {
+    isNotNull();
+    return hasBinaryAnnotation(key, utf8Expected.getBytes(Util.UTF_8));
+  }
+
+  public SpanAssert hasBinaryAnnotation(final String key, byte[] expected) {
+    isNotNull();
+    List<String> keys = new ArrayList<>();
+    for (BinaryAnnotation b : actual.binaryAnnotations) {
+      if (b.key.equals(key)) {
+        arrays.assertContains(info, b.value, expected);
+        return this;
+      }
+      keys.add(b.key);
+    }
+    failWithMessage("\nExpecting binaryAnnotation keys to contain %s, was: <%s>", key, keys);
+    return this;
+  }
+}

--- a/zipkin-java-core/src/test/java/io/zipkin/assertj/ZipkinAssertions.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/assertj/ZipkinAssertions.java
@@ -11,20 +11,15 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.server;
+package io.zipkin.assertj;
 
-import com.twitter.zipkin.storage.SpanStore;
-import com.twitter.zipkin.storage.SpanStoreSpec;
-import io.zipkin.interop.ScalaSpanStoreAdapter;
+import org.assertj.core.api.Assertions;
 
-public class InMemoryScalaSpanStoreTest extends SpanStoreSpec {
-  private InMemorySpanStore mem = new InMemorySpanStore();
+import io.zipkin.Span;
 
-  public SpanStore store() {
-    return new ScalaSpanStoreAdapter(mem);
-  }
+public class ZipkinAssertions extends Assertions {
 
-  public void clear() {
-    mem.clear();
+  public static SpanAssert assertThat(Span actual) {
+    return new SpanAssert(actual);
   }
 }

--- a/zipkin-java-interop/pom.xml
+++ b/zipkin-java-interop/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <zipkin-scala.version>1.21.1</zipkin-scala.version>
+    <zipkin-scala.version>1.25.0</zipkin-scala.version>
     <scalatest.version>2.2.5</scalatest.version>
   </properties>
 

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
@@ -40,10 +40,14 @@ public final class ScalaDependencyStoreAdapter extends com.twitter.zipkin.storag
   }
 
   @Override
-  public Future<Seq<DependencyLink>> getDependencies(Option<Object> startTs, Option<Object> endTs) {
-    List<io.zipkin.DependencyLink> input = spanStore.getDependencies(
-        startTs.isDefined() ? (Long) startTs.get() : null,
-        endTs.isDefined() ? (Long) endTs.get() : null
+  public Option<Object> getDependencies$default$2() {
+    return Option.empty();
+  }
+
+  @Override
+  public Future<Seq<DependencyLink>> getDependencies(long endTs, Option<Object> lookback) {
+    List<io.zipkin.DependencyLink> input = spanStore.getDependencies(endTs,
+        lookback.isDefined() ? (Long) lookback.get() : null
     );
     List<DependencyLink> links = new ArrayList<>(input.size());
     for (io.zipkin.DependencyLink link : input) {
@@ -53,11 +57,6 @@ public final class ScalaDependencyStoreAdapter extends com.twitter.zipkin.storag
       }
     }
     return Future.value(JavaConversions.asScalaBuffer(links).seq());
-  }
-
-  @Override
-  public Option<Object> getDependencies$default$2() {
-    return Option.empty();
   }
 
   @Override

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -54,7 +54,10 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
     io.zipkin.QueryRequest.Builder request = new io.zipkin.QueryRequest.Builder()
         .serviceName(input.serviceName())
         .spanName(input.spanName().isDefined() ? input.spanName().get() : null)
+        .minDuration(input.minDuration().isDefined() ? (Long) input.minDuration().get() : null)
+        .maxDuration(input.maxDuration().isDefined() ? (Long) input.maxDuration().get() : null)
         .endTs(input.endTs())
+        .lookback(input.lookback())
         .limit(input.limit());
 
     for (Iterator<String> i = input.annotations().iterator(); i.hasNext(); ) {

--- a/zipkin-java-interop/src/test/java/io/zipkin/SpanStoreTest.java
+++ b/zipkin-java-interop/src/test/java/io/zipkin/SpanStoreTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base test for {@link SpanStore} implementations. Subtypes should create a connection to a real
+ * backend, even if that backend is in-process.
+ *
+ * <p/>Incrementally, this will replace {@code com.twitter.zipkin.storage.SpanStoreSpec}.
+ */
+public abstract class SpanStoreTest<T extends SpanStore> {
+
+  /** Should maintain state between multiple calls within a test. */
+  protected final T store;
+
+  protected SpanStoreTest(T store) {
+    this.store = store;
+  }
+
+  /** Clears the span store between tests. */
+  @Before
+  public abstract void clear();
+
+  Endpoint ep = Endpoint.create("service", 127 << 24 | 1, 8080);
+
+  long spanId = 456;
+  Annotation ann1 = Annotation.create(1000L, "cs", ep);
+  Annotation ann2 = Annotation.create(2000L, "sr", null);
+  Annotation ann3 = Annotation.create(10000L, "custom", ep);
+  Annotation ann4 = Annotation.create(20000L, "custom", ep);
+  Annotation ann5 = Annotation.create(5000L, "custom", ep);
+  Annotation ann6 = Annotation.create(6000L, "custom", ep);
+  Annotation ann7 = Annotation.create(7000L, "custom", ep);
+  Annotation ann8 = Annotation.create(8000L, "custom", ep);
+
+  Span span1 = new Span.Builder()
+      .traceId(123)
+      .name("methodcall")
+      .id(spanId)
+      .addAnnotation(ann1)
+      .addAnnotation(ann3)
+      .addBinaryAnnotation(BinaryAnnotation.create("BAH", "BEH", ep)).build();
+
+  Span span2 = new Span.Builder()
+      .traceId(456)
+      .name("methodcall")
+      .id(spanId)
+      .timestamp(2L)
+      .addAnnotation(ann2)
+      .addBinaryAnnotation(BinaryAnnotation.create("BAH2", "BEH2", ep)).build();
+
+  Span span3 = new Span.Builder()
+      .traceId(789)
+      .name("methodcall")
+      .id(spanId)
+      .addAnnotation(ann2)
+      .addAnnotation(ann3)
+      .addAnnotation(ann4)
+      .addBinaryAnnotation(BinaryAnnotation.create("BAH2", "BEH2", ep)).build();
+
+  Span span4 = new Span.Builder()
+      .traceId(999)
+      .name("methodcall")
+      .id(spanId)
+      .addAnnotation(ann6)
+      .addAnnotation(ann7).build();
+
+  Span span5 = new Span.Builder()
+      .traceId(999)
+      .name("methodcall")
+      .id(spanId)
+      .addAnnotation(ann5)
+      .addAnnotation(ann8)
+      .addBinaryAnnotation(BinaryAnnotation.create("BAH2", "BEH2", ep)).build();
+
+  Span spanEmptySpanName = new Span.Builder()
+      .traceId(123)
+      .name("")
+      .id(spanId)
+      .parentId(1L)
+      .addAnnotation(ann1)
+      .addAnnotation(ann2).build();
+
+  Span spanEmptyServiceName = new Span.Builder()
+      .traceId(123)
+      .name("spanname")
+      .id(spanId).build();
+
+  Span mergedSpan = new Span.Builder()
+      .traceId(123)
+      .name("methodcall")
+      .id(spanId)
+      .addAnnotation(ann1)
+      .addAnnotation(ann2)
+      .addBinaryAnnotation(BinaryAnnotation.create("BAH2", "BEH2", ep)).build();
+
+  /**
+   * Basic clock skew correction is something span stores should support, until the UI supports
+   * happens-before without using timestamps. The easiest clock skew to correct is where a child
+   * appears to happen before the parent.
+   *
+   * <p/>It doesn't matter if clock-skew correction happens at storage or query time, as long as it
+   * occurs by the time results are returned.
+   *
+   * <p/>Span stores who don't support this can override and disable this test, noting in the README
+   * the limitation.
+   */
+  @Test
+  public void correctsClockSkew() {
+    Endpoint client = Endpoint.create("client", 192 << 24 | 168 << 16 | 1, 8080);
+    Endpoint frontend = Endpoint.create("frontend", 192 << 24 | 168 << 16 | 2, 8080);
+    Endpoint backend = Endpoint.create("backend", 192 << 24 | 168 << 16 | 3, 8080);
+
+    Span parent = new Span.Builder()
+        .traceId(1)
+        .name("method1")
+        .id(666)
+        .addAnnotation(Annotation.create(100000, Constants.CLIENT_SEND, client))
+        .addAnnotation(Annotation.create(95000, Constants.SERVER_RECV, frontend)) // before client sends
+        .addAnnotation(Annotation.create(120000, Constants.SERVER_SEND, frontend)) // before client receives
+        .addAnnotation(Annotation.create(135000, Constants.CLIENT_RECV, client)).build();
+
+    Span child = new Span.Builder()
+        .traceId(1)
+        .name("method2")
+        .id(777)
+        .parentId(666L)
+        .addAnnotation(Annotation.create(100000, Constants.CLIENT_SEND, frontend))
+        .addAnnotation(Annotation.create(115000, Constants.SERVER_RECV, backend))
+        .addAnnotation(Annotation.create(120000, Constants.SERVER_SEND, backend))
+        .addAnnotation(Annotation.create(115000, Constants.CLIENT_RECV, frontend)) // before server sent
+        .build();
+
+    List<Span> skewed = asList(parent, child);
+
+    // There's clock skew when the child doesn't happen after the parent
+    assertThat(skewed.get(0).timestamp)
+        .isLessThanOrEqualTo(skewed.get(1).timestamp);
+
+    // Regardless of when clock skew is corrected, it should be corrected before traces return
+    store.accept(asList(parent, child));
+    List<Span> adjusted = store.getTracesByIds(asList(1L)).get(0);
+
+    // After correction, the child happens after the parent
+    assertThat(adjusted.get(0).timestamp)
+        .isLessThanOrEqualTo(adjusted.get(1).timestamp);
+
+    // .. because the child is shifted to a later date
+    assertThat(adjusted.get(1).timestamp)
+        .isGreaterThan(skewed.get(1).timestamp);
+
+    // Since we've shifted the child to a later timestamp, the total duration appears shorter
+    assertThat(adjusted.get(0).duration)
+        .isLessThan(skewed.get(0).duration);
+
+    // .. but that change in duration should be accounted for
+    long shift = adjusted.get(0).timestamp - skewed.get(0).timestamp;
+    assertThat(adjusted.get(0).duration)
+        .isEqualTo(skewed.get(0).duration - shift);
+  }
+}

--- a/zipkin-java-interop/src/test/java/io/zipkin/jdbc/JDBCSpanStoreTest.java
+++ b/zipkin-java-interop/src/test/java/io/zipkin/jdbc/JDBCSpanStoreTest.java
@@ -11,20 +11,22 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.zipkin.server;
+package io.zipkin.jdbc;
 
-import com.twitter.zipkin.storage.SpanStore;
-import com.twitter.zipkin.storage.SpanStoreSpec;
-import io.zipkin.interop.ScalaSpanStoreAdapter;
+import io.zipkin.SpanStoreTest;
+import java.sql.SQLException;
 
-public class InMemoryScalaSpanStoreTest extends SpanStoreSpec {
-  private InMemorySpanStore mem = new InMemorySpanStore();
+public class JDBCSpanStoreTest extends SpanStoreTest<JDBCSpanStore> {
 
-  public SpanStore store() {
-    return new ScalaSpanStoreAdapter(mem);
+  public JDBCSpanStoreTest() throws SQLException {
+    super(new JDBCTestGraph().spanStore);
   }
 
   public void clear() {
-    mem.clear();
+    try {
+      store.clear();
+    } catch (SQLException e) {
+      throw new AssertionError(e);
+    }
   }
 }

--- a/zipkin-java-interop/src/test/java/io/zipkin/server/InMemorySpanStoreTest.java
+++ b/zipkin-java-interop/src/test/java/io/zipkin/server/InMemorySpanStoreTest.java
@@ -13,18 +13,14 @@
  */
 package io.zipkin.server;
 
-import com.twitter.zipkin.storage.SpanStore;
-import com.twitter.zipkin.storage.SpanStoreSpec;
-import io.zipkin.interop.ScalaSpanStoreAdapter;
+import io.zipkin.SpanStoreTest;
 
-public class InMemoryScalaSpanStoreTest extends SpanStoreSpec {
-  private InMemorySpanStore mem = new InMemorySpanStore();
-
-  public SpanStore store() {
-    return new ScalaSpanStoreAdapter(mem);
+public class InMemorySpanStoreTest extends SpanStoreTest<InMemorySpanStore> {
+  public InMemorySpanStoreTest() {
+    super(new InMemorySpanStore());
   }
 
   public void clear() {
-    mem.clear();
+    store.clear();
   }
 }

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinSpans.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinSpans.java
@@ -41,7 +41,7 @@ import org.jooq.impl.TableImpl;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class ZipkinSpans extends TableImpl<Record> {
 
-	private static final long serialVersionUID = 107308884;
+	private static final long serialVersionUID = 851868507;
 
 	/**
 	 * The reference instance of <code>zipkin.zipkin_spans</code>
@@ -82,9 +82,14 @@ public class ZipkinSpans extends TableImpl<Record> {
 	public final TableField<Record, Boolean> DEBUG = createField("debug", org.jooq.impl.SQLDataType.BIT, this, "");
 
 	/**
-	 * The column <code>zipkin.zipkin_spans.start_ts</code>. Used to implement TTL; First Annotation.timestamp() or null
+	 * The column <code>zipkin.zipkin_spans.start_ts</code>. Span.timestamp(): epoch micros used for endTs query and to implement TTL
 	 */
-	public final TableField<Record, Long> START_TS = createField("start_ts", org.jooq.impl.SQLDataType.BIGINT, this, "Used to implement TTL; First Annotation.timestamp() or null");
+	public final TableField<Record, Long> START_TS = createField("start_ts", org.jooq.impl.SQLDataType.BIGINT, this, "Span.timestamp(): epoch micros used for endTs query and to implement TTL");
+
+	/**
+	 * The column <code>zipkin.zipkin_spans.duration</code>. Span.duration(): micros used for minDuration and maxDuration query
+	 */
+	public final TableField<Record, Long> DURATION = createField("duration", org.jooq.impl.SQLDataType.BIGINT, this, "Span.duration(): micros used for minDuration and maxDuration query");
 
 	/**
 	 * Create a <code>zipkin.zipkin_spans</code> table reference

--- a/zipkin-java-jdbc/src/main/resources/mysql.sql
+++ b/zipkin-java-jdbc/src/main/resources/mysql.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   `name` VARCHAR(255) NOT NULL,
   `parent_id` BIGINT,
   `debug` BIT(1),
-  `start_ts` BIGINT COMMENT 'Used to implement TTL; First Annotation.timestamp() or null'
+  `start_ts` BIGINT COMMENT 'Span.timestamp(): epoch micros used for endTs query and to implement TTL',
+  `duration` BIGINT COMMENT 'Span.duration(): micros used for minDuration and maxDuration query'
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
 ALTER TABLE zipkin_spans ADD UNIQUE KEY(`trace_id`, `id`) COMMENT 'ignore insert on duplicate';
@@ -32,4 +33,3 @@ ALTER TABLE zipkin_annotations ADD INDEX(`endpoint_service_name`) COMMENT 'for g
 ALTER TABLE zipkin_annotations ADD INDEX(`a_type`) COMMENT 'for getTraces';
 ALTER TABLE zipkin_annotations ADD INDEX(`a_key`) COMMENT 'for getTraces';
 ALTER TABLE zipkin_annotations ADD INDEX(`endpoint_ipv4`) COMMENT 'for getTraces ordering';
-

--- a/zipkin-java-server/Dockerfile
+++ b/zipkin-java-server/Dockerfile
@@ -12,7 +12,7 @@
 # the License.
 #
 
-FROM openzipkin/zipkin-base:base-1.21.1
+FROM openzipkin/zipkin-base:base-1.25.0
 
 MAINTAINER OpenZipkin "http://zipkin.io/"
 

--- a/zipkin-java-server/pom.xml
+++ b/zipkin-java-server/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <brave.version>3.0.0</brave.version>
+    <brave.version>3.1.0</brave.version>
     <start-class>io.zipkin.server.ZipkinServer</start-class>
   </properties>
 
@@ -63,7 +63,7 @@
 
     <dependency>
       <groupId>com.github.kristofa</groupId>
-      <artifactId>brave-zipkin-spancollector</artifactId>
+      <artifactId>brave-spancollector-scribe</artifactId>
       <version>${brave.version}</version>
     </dependency>
 

--- a/zipkin-java-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-java-server/src/main/resources/zipkin-server.yml
@@ -9,6 +9,8 @@ zipkin:
     type: ${STORAGE_TYPE:mem}
 server:
   port: ${QUERY_PORT:9411}
+  compression:
+    enabled: true
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver

--- a/zipkin-java-server/src/test/java/io/zipkin/server/brave/SpanStoreSpanCollectorTest.java
+++ b/zipkin-java-server/src/test/java/io/zipkin/server/brave/SpanStoreSpanCollectorTest.java
@@ -50,6 +50,7 @@ public class SpanStoreSpanCollectorTest {
     Span span = new Span();
     span.setId(id);
     span.setTrace_id(traceId);
+    span.setParent_id(traceId);
     span.setName(spanName);
     Annotation annotation = new Annotation();
     annotation.setHost(new Endpoint(0, (short) 80, service));


### PR DESCRIPTION
* Adds duration and lookback queries
* Added docs for all core datatypes
* Uses "on duplicate key update" to merge late arriving span metadata
* Adds gzip compression of api traffic
* Adds clock skew adjustment