### PR TITLE
Adds bootstrap and codec to self-tracing

### DIFF
--- a/zipkin-java-server/pom.xml
+++ b/zipkin-java-server/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <brave.version>3.1.0</brave.version>
+    <brave.version>3.2.0</brave.version>
     <start-class>io.zipkin.server.ZipkinServer</start-class>
   </properties>
 

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServer.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServer.java
@@ -13,6 +13,7 @@
  */
 package io.zipkin.server;
 
+import io.zipkin.server.brave.BootstrapTrace;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
@@ -22,7 +23,7 @@ public class ZipkinServer {
 
   public static void main(String[] args) {
     new SpringApplicationBuilder(ZipkinServer.class)
+        .listeners(BootstrapTrace.INSTANCE::record)
         .properties("spring.config.name=zipkin-server").run(args);
   }
-
 }

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/BootstrapTrace.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/BootstrapTrace.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.server.brave;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.LocalTracer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEvent;
+
+/** This decouples bootstrap tracing from trace initialization. */
+public enum BootstrapTrace {
+  INSTANCE;
+
+  private final Map<String, Long> annotations = new LinkedHashMap<>();
+  private final long timestamp = System.currentTimeMillis() * 1000;
+  private final long startTick = System.nanoTime();
+
+  public void record(ApplicationEvent event) {
+    annotations.put(event.getClass().getSimpleName().replace("Event", ""), timestamp + microsSinceInit());
+    // record duration and flush the trace if we're done
+    if (event instanceof ApplicationReadyEvent) {
+      long duration = microsSinceInit(); // get duration now, as below logic might skew things.
+      ApplicationReadyEvent ready = (ApplicationReadyEvent) event;
+      LocalTracer tracer = ready.getApplicationContext().getBeanFactory()
+                                .getBean(Brave.class).localTracer();
+
+      tracer.startNewSpan("spring-boot", "bootstrap", timestamp);
+      annotations.forEach((value, timestamp) -> tracer.submitAnnotation(value, timestamp));
+      tracer.finishSpan(duration);
+    }
+  }
+
+  private long microsSinceInit() {
+    return (System.nanoTime() - startTick) / 1000;
+  }
+}

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2015 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.zipkin.server.brave;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.LocalTracer;
+import io.zipkin.DependencyLink;
+import io.zipkin.QueryRequest;
+import io.zipkin.Span;
+import io.zipkin.SpanStore;
+import io.zipkin.internal.Nullable;
+import java.util.List;
+
+public final class TraceWritesSpanStore implements SpanStore {
+  private final LocalTracer tracer;
+  private final SpanStore delegate;
+  private final String component;
+
+  public TraceWritesSpanStore(Brave brave, SpanStore delegate) {
+    this.tracer = brave.localTracer();
+    this.delegate = delegate;
+    this.component = delegate.getClass().getSimpleName();
+  }
+
+  @Override
+  public void accept(List<Span> spans) {
+    delegate.accept(spans); // don't trace writes
+  }
+
+  @Override
+  public List<List<Span>> getTraces(QueryRequest request) {
+    if (tracer.startNewSpan(component, "get-traces") != null) {
+      tracer.submitBinaryAnnotation("request", request.toString());
+    }
+    try {
+      return delegate.getTraces(request);
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
+  public List<List<Span>> getTracesByIds(List<Long> traceIds) {
+    tracer.startNewSpan(component, "get-traces-by-ids");
+    try {
+      return delegate.getTracesByIds(traceIds);
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
+  public List<String> getServiceNames() {
+    tracer.startNewSpan(component, "get-service-names");
+    try {
+      return delegate.getServiceNames();
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
+  public List<String> getSpanNames(String serviceName) {
+    tracer.startNewSpan(component, "get-span-names");
+    try {
+      return delegate.getSpanNames(serviceName);
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
+    tracer.startNewSpan(component, "get-dependencies");
+    try {
+      return delegate.getDependencies(endTs, lookback);
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}


### PR DESCRIPTION
The scala project logs a local trace of bootstrap, to serve as an
example of how to do that. This adds a local trace, including the same
start signal (init), but spring-boot specific annotations for lifecycle
events.

This also adds a SpanStore tracer (except for writes), to show an
example of how to trace a local component

Here's an example bootstrap trace from docker on my macbook pro:

<img width="675" alt="screen shot 2015-11-17 at 8 41 06 am" src="https://cloud.githubusercontent.com/assets/64215/11217835/311d937a-8d07-11e5-98bb-ce6d068969e0.png">

And here's an example of how much time zipkin spends actually retrieving spans (vs http/api overhead):

<img width="974" alt="screen shot 2015-11-23 at 7 12 00 am" src="https://cloud.githubusercontent.com/assets/64215/11340168/9c65c162-91b1-11e5-9b55-04916e58bcb3.png">

This change is awaiting a release of brave 3.2