### PR TITLE
Moves codec ops to an interface in preparation of tracing

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/Codec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Codec.java
@@ -23,30 +23,46 @@ import java.util.List;
  */
 public interface Codec {
 
+  interface Factory {
+    /** Returns a codec for the given media type (ex. "application/json") or null if not found. */
+    @Nullable
+    Codec get(String mediaType);
+  }
+
   Codec JSON = new JsonCodec();
   Codec THRIFT = new ThriftCodec();
 
-  /** Returns null if the span couldn't be decoded */
-  @Nullable
-  Span readSpan(byte[] bytes);
+  Factory FACTORY = new Factory() {
 
-  /** Returns null if the span couldn't be encoded */
-  @Nullable
-  byte[] writeSpan(Span value);
+    @Override
+    public Codec get(String mediaType) {
+      if (mediaType.startsWith("application/json")) {
+        return JSON;
+      } else if (mediaType.startsWith("application/x-thrift")) {
+        return THRIFT;
+      }
+      return null;
+    }
+  };
+
 
   /** Returns null if the spans couldn't be decoded */
   @Nullable
   List<Span> readSpans(byte[] bytes);
 
-  /** Returns null if the span couldn't be encoded */
+  /** Returns null if the spans couldn't be encoded */
   @Nullable
   byte[] writeSpans(List<Span> value);
 
-  /** Returns null if the dependency link couldn't be decoded */
+  /** Returns null if the traces couldn't be encoded */
   @Nullable
-  DependencyLink readDependencyLink(byte[] bytes);
+  byte[] writeTraces(List<List<Span>> value);
 
-  /** Returns null if the dependency link couldn't be encoded */
+  /** Returns null if the dependency links couldn't be decoded */
   @Nullable
-  byte[] writeDependencyLink(DependencyLink value);
+  List<DependencyLink> readDependencyLinks(byte[] bytes);
+
+  /** Returns null if the dependency links couldn't be encoded */
+  @Nullable
+  byte[] writeDependencyLinks(List<DependencyLink> value);
 }

--- a/zipkin-java-core/src/main/java/io/zipkin/internal/Util.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/internal/Util.java
@@ -18,12 +18,10 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import okio.Buffer;
 
 public final class Util {
   public static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -93,27 +91,6 @@ public final class Util {
 
     Collections.sort(result);
     return result;
-  }
-
-  /** Only here as this is a Java 7 module. */
-  public interface Serializer<T> {
-    byte[] apply(T in);
-  }
-
-  public static <T> Serializer<List<T>> writeJsonList(final Serializer<T> elementWriter) {
-    return new Serializer<List<T>>() {
-      @Override
-      public byte[] apply(List<T> input) {
-        Buffer buffer = new Buffer();
-        buffer.writeUtf8CodePoint('[');
-        for (Iterator<T> i = input.iterator(); i.hasNext(); ) {
-          buffer.write(elementWriter.apply(i.next()));
-          if (i.hasNext()) buffer.writeUtf8CodePoint(',');
-        }
-        buffer.writeUtf8CodePoint(']');
-        return buffer.readByteArray();
-      }
-    };
   }
 
   private Util() {

--- a/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/CodecTest.java
@@ -14,8 +14,10 @@
 package io.zipkin;
 
 import java.io.IOException;
+import java.util.List;
 import org.junit.Test;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class CodecTest {
@@ -23,25 +25,17 @@ public abstract class CodecTest {
   protected abstract Codec codec();
 
   @Test
-  public void spanRoundTrip() throws IOException {
-    for (Span span : TestObjects.TRACE) {
-      byte[] bytes = codec().writeSpan(span);
-      assertThat(codec().readSpan(bytes))
-          .isEqualTo(span);
-    }
-  }
-
-  @Test
-  public void spanDecodesToNullOnEmpty() throws IOException {
-    assertThat(codec().readSpan(new byte[0]))
-        .isNull();
-  }
-
-  @Test
   public void spansRoundTrip() throws IOException {
     byte[] bytes = codec().writeSpans(TestObjects.TRACE);
     assertThat(codec().readSpans(bytes))
         .isEqualTo(TestObjects.TRACE);
+  }
+
+  @Test
+  public void writeTraces() throws IOException {
+    byte[] bytes = codec().writeTraces(asList(TestObjects.TRACE, TestObjects.TRACE));
+    assertThat(codec().writeSpans(TestObjects.TRACE).length * 2)
+        .isLessThan(bytes.length);
   }
 
   @Test
@@ -60,16 +54,19 @@ public abstract class CodecTest {
   }
 
   @Test
-  public void dependencyLinkRoundTrip() throws IOException {
-    DependencyLink link = DependencyLink.create("tfe", "mobileweb", 6);
-    byte[] bytes = codec().writeDependencyLink(link);
-    assertThat(codec().readDependencyLink(bytes))
-        .isEqualTo(link);
+  public void dependencyLinksRoundTrip() throws IOException {
+    List<DependencyLink> links = asList(
+        DependencyLink.create("foo", "bar", 2),
+        DependencyLink.create("bar", "baz", 3)
+    );
+    byte[] bytes = codec().writeDependencyLinks(links);
+    assertThat(codec().readDependencyLinks(bytes))
+        .isEqualTo(links);
   }
 
   @Test
-  public void dependencyLinkDecodesToNullOnEmpty() throws IOException {
-    assertThat(codec().readDependencyLink(new byte[0]))
+  public void dependencyLinksDecodeToNullOnEmpty() throws IOException {
+    assertThat(codec().readDependencyLinks(new byte[0]))
         .isNull();
   }
 }

--- a/zipkin-java-core/src/test/java/io/zipkin/internal/UtilTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/internal/UtilTest.java
@@ -13,15 +13,9 @@
  */
 package io.zipkin.internal;
 
-import io.zipkin.internal.Util.Serializer;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 
-import static io.zipkin.internal.Util.UTF_8;
 import static io.zipkin.internal.Util.equal;
-import static io.zipkin.internal.Util.writeJsonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -33,30 +27,5 @@ public class UtilTest {
     assertFalse(equal(null, "1"));
     assertFalse(equal("1", null));
     assertFalse(equal("1", "2"));
-  }
-
-  Serializer<List<Integer>> intsSerializer = writeJsonList(new Serializer<Integer>() {
-    @Override
-    public byte[] apply(Integer in) {
-      return Integer.toString(in).getBytes(UTF_8);
-    }
-  });
-
-  @Test
-  public void writeJsonList_empty() {
-    byte[] bytes = intsSerializer.apply(Arrays.<Integer>asList());
-    assertThat(new String(bytes, UTF_8)).isEqualTo("[]");
-  }
-
-  @Test
-  public void writeJsonList_one() {
-    byte[] bytes = intsSerializer.apply(Arrays.asList(1));
-    assertThat(new String(bytes, UTF_8)).isEqualTo("[1]");
-  }
-
-  @Test
-  public void writeJsonList_two() {
-    byte[] bytes = intsSerializer.apply(Arrays.asList(1, 2));
-    assertThat(new String(bytes, UTF_8)).isEqualTo("[1,2]");
   }
 }


### PR DESCRIPTION
Codec had a larger interface than needed, and instances were used
directly. This moves to an interface for reasons including preparation
of codec tracing via dependency injection.