### PR TITLE
Adjusts environment variables to match zipkin-scala and adds docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@
 #
 
 mysql:
-  image: openzipkin/zipkin-mysql:1.26.0
+  image: openzipkin/zipkin-mysql:1.26.1
   ports:
     - 3306:3306
 query:
@@ -27,7 +27,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.26.0
+  image: openzipkin/zipkin-web:1.26.1
   ports:
     - 8080:8080
   environment:

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
     <moshi.version>1.0.0</moshi.version>
     <okio.version>1.6.0</okio.version>
-    <spring-boot.version>1.3.0.RELEASE</spring-boot.version>
+    <spring-boot.version>1.3.1.RELEASE</spring-boot.version>
     <libthrift.version>0.9.3</libthrift.version>
   </properties>
 

--- a/zipkin-java-interop/pom.xml
+++ b/zipkin-java-interop/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <zipkin-scala.version>1.26.0</zipkin-scala.version>
+    <zipkin-scala.version>1.26.1</zipkin-scala.version>
     <scalatest.version>2.2.5</scalatest.version>
   </properties>
 

--- a/zipkin-java-server/Dockerfile
+++ b/zipkin-java-server/Dockerfile
@@ -12,11 +12,12 @@
 # the License.
 #
 
-FROM openzipkin/zipkin-base:base-1.26.0
+FROM openzipkin/zipkin-base:base-1.26.1
 
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-ENV ZIPKIN_JAVA_VERSION 0.1.1
+ENV ZIPKIN_JAVA_VERSION 0.1.2
+ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 
 VOLUME /tmp
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-java-server/$ZIPKIN_JAVA_VERSION/zipkin-java-server-$ZIPKIN_JAVA_VERSION-exec.jar > zipkin-server.jar
@@ -25,4 +26,4 @@ RUN unzip zipkin-server.jar
 
 EXPOSE 9411
 
-CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java -Djava.security.egd=file:/dev/./urandom -cp '.:lib/*' io.zipkin.server.ZipkinServer
+CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java ${JAVA_OPTS} -cp '.:lib/*' io.zipkin.server.ZipkinServer

--- a/zipkin-java-server/README.md
+++ b/zipkin-java-server/README.md
@@ -1,0 +1,43 @@
+# zipkin-java-server
+The  receives spans via HTTP POST and respond to queries from zipkin-web.
+
+Note that the server requires minimum JRE 8.
+
+## Running locally
+
+To run the server from the currently checked out source, enter the following.
+```bash
+$ ./mvnw -pl zipkin-java-server spring-boot:run
+```
+
+## Environment Variables
+zipkin-java-server is a drop-in replacement for the [scala query service](https://github.com/openzipkin/zipkin/tree/master/zipkin-query-service).
+
+The following environment variables from zipkin-scala are honored.
+
+    * `QUERY_PORT`: Listen lookback for the query http api; Defaults to 9411
+    * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
+    * `QUERY_LOOKBACK`: How many milliseconds queries look back from endTs; Defaults to 7 days
+    * `STORAGE_TYPE`: SpanStore implementation: one of `mem` or `mysql`
+
+### MySQL
+The following apply when `STORAGE_TYPE` is set to `mysql`:
+
+    * `MYSQL_DB`: The database to use. Defaults to "zipkin".
+    * `MYSQL_USER` and `MYSQL_PASS`: MySQL authentication, which defaults to empty string.
+    * `MYSQL_HOST`: Defaults to localhost
+    * `MYSQL_TCP_PORT`: Defaults to 3306
+    * `MYSQL_MAX_CONNECTIONS`: Maximum concurrent connections, defaults to 10
+    * `MYSQL_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
+
+### Docker
+When using docker, the following apply:
+
+    * `ZIPKIN_JAVA_VERSION`: Which published version of zipkin-java is installed
+    * `JAVA_OPTS`: Use to set java arguments, such as heap size or trust store location.
+
+Example usage:
+
+```bash
+$ STORAGE_TYPE=mysql MYSQL_USER=root ./mvnw -pl zipkin-java-server spring-boot:run
+```

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
@@ -17,11 +17,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin")
 class ZipkinServerProperties {
-  private Collector collector = new Collector();
+  private Query query = new Query();
   private Store store = new Store();
 
-  public Collector getCollector() {
-    return this.collector;
+  public Query getQuery() {
+    return this.query;
   }
 
   public Store getStore() {
@@ -44,15 +44,15 @@ class ZipkinServerProperties {
     }
   }
 
-  static class Collector {
-    private int port = 9410;
+  static class Query {
+    private int lookback = 86400000; // 7 days in millis
 
-    public int getPort() {
-      return this.port;
+    public int getLookback() {
+      return this.lookback;
     }
 
-    public void setPort(int port) {
-      this.port = port;
+    public void setLookback(int lookback) {
+      this.lookback = lookback;
     }
   }
 }

--- a/zipkin-java-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-java-server/src/main/resources/zipkin-server.yml
@@ -1,10 +1,15 @@
 mysql:
   host: ${MYSQL_HOST:localhost}
-  port: ${MYSQL_PORT:3306}
-  username: ${MYSQL_USER:root}
+  lookback: ${MYSQL_TCP_PORT:3306}
+  username: ${MYSQL_USER:}
   password: ${MYSQL_PASS:}
   db: ${MYSQL_DB:zipkin}
+  max-active: ${MYSQL_MAX_CONNECTIONS:10}
+  use-ssl: ${MYSQL_USE_SSL:false}
 zipkin:
+  query:
+    # 7 days in millis
+    lookback: ${QUERY_LOOKBACK:86400000}
   store:
     type: ${STORAGE_TYPE:mem}
 server:
@@ -14,9 +19,10 @@ server:
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mysql://${mysql.host}:${mysql.port}/${mysql.db}?autoReconnect=true
+    url: jdbc:mysql://${mysql.host}:${mysql.lookback}/${mysql.db}?autoReconnect=true&useSSL=${mysql.use-ssl}
     username: ${mysql.username}
     password: ${mysql.password}
+    max-active: ${mysql.max-active}
     schema: classpath:/mysql.sql
 # Switch this on to create the schema on startup:
     initialize: false


### PR DESCRIPTION
This adds docs regarding which environment variables are supported. It
also corrects `MYSQL_PORT` which is actually `MYSQL_TCP_PORT`.