### PR TITLE
Automagically deal with copyright year updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 The OpenZipkin Authors
+    Copyright 2015-2016 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -256,6 +256,13 @@
           </excludes>
           <strictCheck>true</strictCheck>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin-git</artifactId>
+            <version>${maven-license-plugin.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>

--- a/src/etc/header.txt
+++ b/src/etc/header.txt
@@ -1,4 +1,4 @@
-Copyright 2015 The OpenZipkin Authors
+Copyright ${license.git.copyrightYears} The OpenZipkin Authors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Per CONTRIBUTING.md, license headers are updatable via `./mvnw com.mycila:license-maven-plugin:format`. The impact of this config is that the first update to a file per year needs to change the range. Ex. `2015` to `2015-2016`