### PR TITLE
Adds BeforeTheFactSamplingBenchmarks to support future samplers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_install:
 
 script:
   # If we aren't a pull request, we are publishing either a snapshot or a release.
-  #   We don't currently publish the interop module, as this is test code only.
-  - '[ "${TRAVIS_BRANCH}" = master ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw -s ./.settings.xml -Prelease -pl -zipkin-java-interop deploy -nsu'
+  #   We don't currently publish the benchmarks or interop modules, as they are test code only.
+  - '[ "${TRAVIS_BRANCH}" = master ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw -s ./.settings.xml -Prelease -pl -zipkin-java-benchmarks,-zipkin-java-interop deploy -nsu'
   # If we are on a pull request, don't build javadoc or source jars (release profile), and certainly don't deploy!
   #   We also add the MYSQL_USER so that these tests will be invoked.
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] || MYSQL_USER=travis ./mvnw install -nsu'

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
   <modules>
     <module>zipkin-java-core</module>
+    <module>zipkin-java-benchmarks</module>
     <module>zipkin-java-interop</module>
     <module>zipkin-java-jdbc</module>
     <module>zipkin-java-server</module>

--- a/zipkin-java-benchmarks/README.md
+++ b/zipkin-java-benchmarks/README.md
@@ -1,0 +1,11 @@
+Zipkin Java Benchmarks
+===================
+
+This module includes [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmarks for Zipkin.
+
+=== Running the benchmark
+From the parent directory, run `mvn install` to build the benchmarks, and the following to run them:
+
+```bash
+$ java -jar zipkin-java-benchmarks/target/benchmarks.jar
+```

--- a/zipkin-java-benchmarks/pom.xml
+++ b/zipkin-java-benchmarks/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin</groupId>
+    <artifactId>zipkin-java</artifactId>
+    <version>0.1.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-java-benchmarks</artifactId>
+  <name>Zipkin Java Benchmarks (JMH)</name>
+  <description>Zipkin Java Benchmarks (JMH)</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <jmh.version>1.11.2</jmh.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-java-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>benchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
+++ b/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.benchmarks;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
+ * trace is made before any work is measured, or annotations are added. As such, the input parameter
+ * to zipkin v1 samplers is the trace id (64-bit random number).
+ *
+ * <p>This only tests performance of various approaches against each-other. This doesn't test if the
+ * same trace id is consistently sampled or not, or how close to the retention percentage the
+ * samplers get.
+ *
+ * <p>While random sampling gives a better statistical average across all spans, it's less useful
+ * than the ability to see end to end interrelated work, such as a from a specific user, or messages
+ * blocking others in a queue. More sampling patterns are expected in OpenTracing and Zipkin v2.
+ */
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class BeforeTheFactSamplingBenchmarks {
+
+  /**
+   * Sample rate is a percentage expressed as a float. So, 0.001 is 0.1% (let one in a 1000nd pass).
+   * Zero effectively disables tracing.
+   *
+   * <p>Here are default sample rates from actual implementations:
+   * <pre>
+   * <ul>
+   *   <li>Finagle Scala Tracer: 0.001</li>
+   *   <li>Finagle Ruby Tracer: 0.001</li>
+   *   <li>Brave Java Tracer: 1.0</li>
+   *   <li>Zipkin Collector: 1.0</li>
+   * </ul>
+   * </pre>
+   */
+  static final double SAMPLE_RATE = 0.001;
+
+  @State(Scope.Benchmark)
+  public static class Args {
+
+    /**
+     * Arguments include the most negative number, and an arbitrary one.
+     */
+    // JMH doesn't support Long.MIN_VALUE or hex references, hence the long form literals.
+    @Param({"-9223372036854775808", "1234567890987654321"})
+    long traceId;
+  }
+
+  /**
+   * Zipkin collector's AdjustableGlobalSampler compares the absolute value of the trace id against
+   * a product of the sample rate. It defends against the most negative number in two's complement.
+   *
+   * <p>Collectors receive a trace incrementally and repeat the sampling decision for each part.
+   * This means that consistency against a trace id is a primary feature of this algorithm.
+   *
+   * <p>See https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/sampler/AdjustableGlobalSampler.scala#L55
+   */
+  @Benchmark
+  public boolean compareTraceId_mostNegativeNumberDefense(Args args) {
+    long traceId = args.traceId;
+    // The absolute value of Long.MIN_VALUE is larger than a long, so returns Math.abs identity.
+    // This converts to MAX_VALUE to avoid comparing the sample rate against a negative number.
+    long t = traceId == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(traceId);
+    return t < Long.MAX_VALUE * SAMPLE_RATE; // Constant expression for readability
+  }
+
+  /**
+   * Finagle's scala sampler samples using modulo 10000 arithmetic, which allows a minimum sample
+   * rate of 0.01%.
+   *
+   * <p>This function is only invoked once per trace, propagating the result downstream as a field
+   * called sampled. This means it is designed for instrumented entry-points.
+   *
+   * <p>Trace id collision was noticed in practice in the Twitter front-end cluster. A random salt
+   * feature was added to defend against nodes in the same cluster sampling exactly the same subset
+   * of trace ids. The goal was full 64-bit coverage of traceIds on multi-host deployments.
+   *
+   * <p>See https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+   */
+  @Benchmark
+  public boolean compareTraceId_modulo10000_salted(Args args) {
+    long traceId = args.traceId;
+    long t = Math.abs(traceId ^ SALT);
+    // Minimum sample rate is one in 10000, or 0.01% of traces
+    return t % 10000 < SAMPLE_RATE * 10000; // Constant expression for readability
+  }
+
+  static final long SALT = new Random().nextLong();
+
+  /**
+   * Finagle's ruby sampler gets a random number and compares that against the sample rate.
+   *
+   * <p>This function is only invoked once per trace, propagating the result downstream as a field
+   * called sampled. This means it is designed for instrumented entry-points.
+   *
+   * <p>See https://github.com/twitter/finagle/blob/develop/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb#L135
+   */
+  @Benchmark
+  public boolean compareRandomNumber(Args args) {
+    return RNG.nextFloat() < SAMPLE_RATE; // notice trace id is not used
+  }
+
+  final Random RNG = new Random();
+
+  /**
+   * Brave's FixedSampleRateTraceFilter uses a shared counter to guarantee an sample ratio. This
+   * approach cannot guarantee a consistent decision, as it doesn't use the trace id. Depending on
+   * implementation, this may or may not be a problem.
+   *
+   * <p>See https://github.com/openzipkin/brave/blob/master/brave-core/src/main/java/com/github/kristofa/brave/FixedSampleRateTraceFilter.java#L37
+   */
+  @Benchmark
+  public boolean compareCounter(Args args) {
+    final int value = COUNTER.incrementAndGet(); // notice trace id is not used
+    if (value >= SAMPLE_RATIO) {
+      synchronized (COUNTER) {
+        if (COUNTER.get() >= SAMPLE_RATIO) {
+          COUNTER.set(0);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private final int SAMPLE_RATIO = 1000; // brave uses ratio as opposed to percentage
+  final AtomicInteger COUNTER = new AtomicInteger();
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + BeforeTheFactSamplingBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
Zipkin v1 uses statistical sampling, both locally in instrumentation and
at the collection-tier. For the zipkin-server to be compatible with the
scala collector, we need to implement the same sampling approach.
Specifically, this is to support the `COLLECTOR_SAMPLE_RATE` property.

A follow-up change will implement a collector, using the
`compareTraceId_mostNegativeNumberDefense` measured here. Other
algorithms are measured for the sake of comparison.

See #52

Here are example results from my mid 2014 MBP
```
Benchmark                                                                            (traceId)   Mode  Cnt    Score    Error   Units
BeforeTheFactSamplingBenchmarks.compareCounter                            -9223372036854775808  thrpt   15  125.485 ±  6.782  ops/us
BeforeTheFactSamplingBenchmarks.compareCounter                             1234567890987654321  thrpt   15  127.238 ± 15.187  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                       -9223372036854775808  thrpt   15   98.988 ±  5.962  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                        1234567890987654321  thrpt   15   95.632 ±  1.838  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted         -9223372036854775808  thrpt   15  246.522 ± 13.821  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted          1234567890987654321  thrpt   15  259.952 ± 11.572  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense  -9223372036854775808  thrpt   15  365.788 ± 26.133  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense   1234567890987654321  thrpt   15  341.936 ± 15.102  ops/us
```