### PR TITLE
Honor COLLECTOR_SAMPLE_RATE with TraceIdSampler

### DIFF
--- a/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
+++ b/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
@@ -13,6 +13,10 @@
  */
 package io.zipkin.benchmarks;
 
+import io.zipkin.TraceIdSampler;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -27,10 +31,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
@@ -67,7 +67,7 @@ public class BeforeTheFactSamplingBenchmarks {
    * </ul>
    * </pre>
    */
-  static final double SAMPLE_RATE = 0.001;
+  static final float SAMPLE_RATE = 0.001f;
 
   @State(Scope.Benchmark)
   public static class Args {
@@ -79,6 +79,16 @@ public class BeforeTheFactSamplingBenchmarks {
     @Param({"-9223372036854775808", "1234567890987654321"})
     long traceId;
   }
+
+  /**
+   * This measures the trace id sampler provided with zipkin-java
+   */
+  @Benchmark
+  public boolean traceIdSampler(Args args) {
+    return TRACE_ID_SAMPLER.test(args.traceId);
+  }
+
+  static final TraceIdSampler TRACE_ID_SAMPLER = TraceIdSampler.create(SAMPLE_RATE);
 
   /**
    * Zipkin collector's AdjustableGlobalSampler compares the absolute value of the trace id against

--- a/zipkin-java-core/pom.xml
+++ b/zipkin-java-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 The OpenZipkin Authors
+    Copyright 2015-2016 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -28,8 +28,6 @@
   <description>Zipkin Java Core</description>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
     <main.basedir>${project.basedir}/..</main.basedir>
     <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
   </properties>
@@ -47,6 +45,28 @@
 
   <build>
     <plugins>
+      <plugin>
+        <inherited>true</inherited>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+        <executions>
+          <!-- Ensure main source tree compiles to Java 7 bytecode. -->
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <source>1.7</source>
+              <target>1.7</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Make sure Java 8 types and methods aren't used -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package io.zipkin;
 
 import io.zipkin.internal.Nullable;
 import java.io.Closeable;
+import java.util.Iterator;
 import java.util.List;
 
 public interface SpanStore extends Closeable {
@@ -22,7 +23,8 @@ public interface SpanStore extends Closeable {
   /**
    * Sinks the given spans, ignoring duplicate annotations.
    */
-  void accept(List<Span> spans);
+  // Iterator to permit simple filtering without Java 8 or third-party types.
+  void accept(Iterator<Span> spans);
 
   /**
    * Get the available trace information from the storage system. Spans in trace are sorted by the

--- a/zipkin-java-core/src/main/java/io/zipkin/TraceIdSampler.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/TraceIdSampler.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin;
+
+import static io.zipkin.internal.Util.checkArgument;
+
+/**
+ * Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the trace
+ * is made before any work is measured, or annotations are added. As such, the input parameter to
+ * zipkin v1 samplers is the trace id (64-bit random number).
+ *
+ * <p>The implementation is based on zipkin-scala's AdjustableGlobalSampler. It is percentage based,
+ * and its accuracy is tied to distribution of traceIds across 64bits. For example, tests have shown
+ * an error rate of 3% when traceIds are random. It is idempotent, ie a consistent decision for a
+ * given trace id.
+ */
+// abstract for factory-method support on Java language level 7
+public abstract class TraceIdSampler {
+
+  /**
+   * Returns true if the traceId should be retained.
+   *
+   * <p>This implementation compares the absolute value of the trace id against a product of the
+   * sample rate. It defends against the most negative number in two's complement.
+   */
+  public abstract boolean test(long traceId);
+
+  /**
+   * Returns a constant sampler, given a rate expressed as a percentage.
+   *
+   * @param rate minimum sample rate is 0.0001, or 0.01% of traces
+   */
+  public static TraceIdSampler create(float rate) {
+    if (rate == 0.0) return NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    return new ThresholdSampler(rate);
+  }
+
+  static final TraceIdSampler ALWAYS_SAMPLE = new TraceIdSampler() {
+    @Override
+    public boolean test(long traceId) {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "ALWAYS_SAMPLE";
+    }
+  };
+
+  static final TraceIdSampler NEVER_SAMPLE = new TraceIdSampler() {
+    @Override
+    public boolean test(long traceId) {
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "NEVER_SAMPLE";
+    }
+  };
+
+  /**
+   * Given the absolute value of a random 64 bit trace id, we expect inputs to be balanced across
+   * 0-MAX. Threshold is the range of inputs between 0-MAX that we retain.
+   */
+  static final class ThresholdSampler extends TraceIdSampler {
+
+    private final long threshold;
+
+    ThresholdSampler(float rate) {
+      checkArgument(rate > 0 && rate < 1, "rate should be between 0 and 1: was %s", rate);
+      this.threshold = (long) (Long.MAX_VALUE * rate); // safe cast as rate is less than 1
+    }
+
+    /**
+     * Returns true if the traceId should be retained.
+     *
+     * <p>This implementation compares the absolute value of the trace id against a product of the
+     * sample rate. It defends against the most negative number in two's complement.
+     */
+    @Override
+    public boolean test(long traceId) {
+      // The absolute value of Long.MIN_VALUE is larger than a long, so returns Math.abs identity.
+      // This converts to MAX_VALUE to avoid always dropping when traceId == Long.MIN_VALUE
+      long t = traceId == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(traceId);
+      return t < threshold;
+    }
+
+    @Override
+    public String toString() {
+      return "ThresholdSampler(" + threshold + ")";
+    }
+  }
+}

--- a/zipkin-java-core/src/test/java/io/zipkin/TraceIdSamplerTest.java
+++ b/zipkin-java-core/src/test/java/io/zipkin/TraceIdSamplerTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin;
+
+import java.util.Random;
+import java.util.stream.LongStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class TraceIdSamplerTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large input to avoid
+   * flaking out due to PRNG nuance.
+   */
+  long[] traceIds = new Random().longs(100000).toArray();
+
+  /**
+   * Math.abs(Long.MIN_VALUE) returns a negative, we coerse to Long.MAX_VALUE to avoid always
+   * dropping when trace_id == Long.MIN_VALUE
+   */
+  @Test
+  public void mostNegativeNumberDefence() {
+    TraceIdSampler sampler = TraceIdSampler.create(0.1f);
+
+    assertThat(sampler.test(Long.MIN_VALUE))
+        .isEqualTo(sampler.test(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void retain10Percent() {
+    float sampleRate = 0.1f;
+    TraceIdSampler sampler = TraceIdSampler.create(sampleRate);
+
+    long passCount = LongStream.of(traceIds).filter(sampler::test).count();
+
+    assertThat(passCount)
+        .isCloseTo((long) (traceIds.length * sampleRate), withPercentage(3));
+  }
+
+  /**
+   * The collector needs to apply the same decision to incremental updates in a trace.
+   */
+  @Test
+  public void idempotent() {
+    TraceIdSampler sampler1 = TraceIdSampler.create(0.1f);
+    TraceIdSampler sampler2 = TraceIdSampler.create(0.1f);
+
+    assertThat(LongStream.of(traceIds).filter(sampler1::test).toArray())
+        .containsExactly(LongStream.of(traceIds).filter(sampler2::test).toArray());
+  }
+
+  @Test
+  public void zeroMeansDropAllTraces() {
+    TraceIdSampler sampler = TraceIdSampler.create(0.0f);
+    assertThat(sampler).isSameAs(TraceIdSampler.NEVER_SAMPLE);
+
+    assertThat(LongStream.of(traceIds).filter(sampler::test).findAny())
+        .isEmpty();
+  }
+
+  @Test
+  public void oneMeansKeepAllTraces() {
+    TraceIdSampler sampler = TraceIdSampler.create(1.0f);
+    assertThat(sampler).isSameAs(TraceIdSampler.ALWAYS_SAMPLE);
+
+    assertThat(LongStream.of(traceIds).filter(sampler::test).toArray())
+        .containsExactly(traceIds);
+  }
+
+  @Test
+  public void rateCantBeNegative() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("rate should be between 0 and 1: was -1.0");
+
+    TraceIdSampler.create(-1.0f);
+  }
+
+  @Test
+  public void rateCantBeOverOne() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("rate should be between 0 and 1: was 1.1");
+
+    TraceIdSampler.create(1.1f);
+  }
+}

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -100,7 +100,7 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
 
   @Override
   public Future<BoxedUnit> apply(Seq<Span> input) {
-    this.spanStore.accept(ScalaSpanStoreAdapter.invert(input));
+    this.spanStore.accept(ScalaSpanStoreAdapter.invert(input).iterator());
     return Future.Unit();
   }
 

--- a/zipkin-java-server/README.md
+++ b/zipkin-java-server/README.md
@@ -19,6 +19,7 @@ The following environment variables from zipkin-scala are honored.
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries look back from endTs; Defaults to 7 days
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem` or `mysql`
+    * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
 ### MySQL
 The following apply when `STORAGE_TYPE` is set to `mysql`:

--- a/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import io.zipkin.internal.Nullable;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -47,9 +48,9 @@ public final class InMemorySpanStore implements SpanStore {
   private final Multimap<String, String> serviceToSpanNames = new Multimap<>(LinkedHashSet::new);
 
   @Override
-  public synchronized void accept(List<Span> spans) {
-    for (Span span : spans) {
-      span = ApplyTimestampAndDuration.apply(span);
+  public synchronized void accept(Iterator<Span> spans) {
+    while (spans.hasNext()) {
+      Span span = ApplyTimestampAndDuration.apply(spans.next());
       long traceId = span.traceId;
       String spanName = span.name;
       traceIdToSpans.put(span.traceId, span);

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerConfiguration.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package io.zipkin.server;
 
+import io.zipkin.TraceIdSampler;
 import javax.sql.DataSource;
 
 import org.jooq.ExecuteListenerProvider;
@@ -20,6 +21,7 @@ import org.jooq.conf.Settings;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -55,6 +57,12 @@ public class ZipkinServerConfiguration {
   @ConditionalOnMissingBean(Codec.Factory.class)
   Codec.Factory codecFactory() {
     return Codec.FACTORY;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(TraceIdSampler.class)
+  TraceIdSampler traceIdSampler(@Value("${zipkin.collector.sample-rate}") float rate) {
+    return TraceIdSampler.create(rate);
   }
 
   @Bean

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,12 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin")
 class ZipkinServerProperties {
-  private Query query = new Query();
   private Store store = new Store();
-
-  public Query getQuery() {
-    return this.query;
-  }
 
   public Store getStore() {
     return this.store;
@@ -41,18 +36,6 @@ class ZipkinServerProperties {
 
     public void setType(Type type) {
       this.type = type;
-    }
-  }
-
-  static class Query {
-    private int lookback = 86400000; // 7 days in millis
-
-    public int getLookback() {
-      return this.lookback;
-    }
-
-    public void setLookback(int lookback) {
-      this.lookback = lookback;
     }
   }
 }

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -62,7 +62,7 @@ public class SpanStoreSpanCollector implements SpanCollector, Flushable {
       }
     }
     if (!spans.isEmpty()) {
-      this.spanStore.accept(spans);
+      this.spanStore.accept(spans.iterator());
     }
   }
 

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
@@ -21,6 +20,7 @@ import io.zipkin.QueryRequest;
 import io.zipkin.Span;
 import io.zipkin.SpanStore;
 import io.zipkin.internal.Nullable;
+import java.util.Iterator;
 import java.util.List;
 
 public final class TraceWritesSpanStore implements SpanStore {
@@ -35,7 +35,7 @@ public final class TraceWritesSpanStore implements SpanStore {
   }
 
   @Override
-  public void accept(List<Span> spans) {
+  public void accept(Iterator<Span> spans) {
     delegate.accept(spans); // don't trace writes
   }
 

--- a/zipkin-java-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-java-server/src/main/resources/zipkin-server.yml
@@ -7,6 +7,9 @@ mysql:
   max-active: ${MYSQL_MAX_CONNECTIONS:10}
   use-ssl: ${MYSQL_USE_SSL:false}
 zipkin:
+  collector:
+    # percentage to traces to retain
+    sample-rate: ${COLLECTOR_SAMPLE_RATE:1.0}
   query:
     # 7 days in millis
     lookback: ${QUERY_LOOKBACK:86400000}

--- a/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinSpanWriterTest.java
+++ b/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinSpanWriterTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.zipkin.server;
+
+import io.zipkin.BinaryAnnotation;
+import io.zipkin.Constants;
+import io.zipkin.Endpoint;
+import io.zipkin.Span;
+import io.zipkin.TraceIdSampler;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class ZipkinSpanWriterTest {
+
+  private InMemorySpanStore spanStore = new InMemorySpanStore();
+
+  private Span.Builder builder = new Span.Builder()
+      .traceId(1234L)
+      .id(1235L)
+      .parentId(1234L)
+      .name("md5")
+      .timestamp(System.currentTimeMillis() * 1000)
+      .duration(150L)
+      .addBinaryAnnotation(BinaryAnnotation.create(Constants.LOCAL_COMPONENT, "digest",
+          Endpoint.create("service", 127 << 24 | 1, 8080)));
+
+  @Test
+  public void debugFlagWins() {
+    ZipkinSpanWriter writer = new ZipkinSpanWriter();
+    writer.sampler = TraceIdSampler.create(0.0f); // never sample
+
+    writer.write(spanStore, asList(builder.debug(true).build()));
+
+    assertThat(spanStore.getServiceNames()).containsExactly("service");
+  }
+
+  @Test
+  public void unsampledSpansArentStored() {
+    ZipkinSpanWriter writer = new ZipkinSpanWriter();
+    writer.sampler = TraceIdSampler.create(0.0f); // never sample
+
+    writer.write(spanStore, asList(builder.build()));
+
+    assertThat(spanStore.getServiceNames()).isEmpty();
+  }
+}


### PR DESCRIPTION
This introduces a port of the zipkin-scala sampler as TraceIdSampler.
This is used to implement the `COLLECTOR_SAMPLE_RATE` env property.

In order to make filtering easy and portable with language level 7, this
changes `SpanStore.accept` to take an iterator as opposed to a list.

Fixes #52