### PR TITLE
Adds instructions for adding contention to benchmarks

### DIFF
--- a/zipkin-java-benchmarks/README.md
+++ b/zipkin-java-benchmarks/README.md
@@ -7,5 +7,8 @@ This module includes [JMH](http://openjdk.java.net/projects/code-tools/jmh/) ben
 From the parent directory, run `mvn install` to build the benchmarks, and the following to run them:
 
 ```bash
+# Run with a single worker thread
 $ java -jar zipkin-java-benchmarks/target/benchmarks.jar
+# Add contention by running with 4 threads
+$ java -jar zipkin-java-benchmarks/target/benchmarks.jar -t4
 ```

--- a/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
+++ b/zipkin-java-benchmarks/src/main/java/io/zipkin/benchmarks/BeforeTheFactSamplingBenchmarks.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -51,6 +52,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
+@Threads(1)
 public class BeforeTheFactSamplingBenchmarks {
 
   /**


### PR DESCRIPTION
Good suggestion by @bensigelman

Here are sample results, first w/ default (single thread). Secondly 4 (same as my core count)

```
Benchmark                                                                            (traceId)   Mode  Cnt    Score    Error   Units
BeforeTheFactSamplingBenchmarks.compareCounter                            -9223372036854775808  thrpt   15  132.766 ±  2.285  ops/us
BeforeTheFactSamplingBenchmarks.compareCounter                             1234567890987654321  thrpt   15  133.453 ±  1.911  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                       -9223372036854775808  thrpt   15   98.178 ±  3.563  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                        1234567890987654321  thrpt   15   96.590 ±  1.774  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted         -9223372036854775808  thrpt   15  250.233 ±  5.966  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted          1234567890987654321  thrpt   15  253.787 ± 10.121  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense  -9223372036854775808  thrpt   15  397.390 ± 13.183  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense   1234567890987654321  thrpt   15  320.624 ±  8.357  ops/us
BeforeTheFactSamplingBenchmarks.traceIdSampler                            -9223372036854775808  thrpt   15  392.581 ±  9.786  ops/us
BeforeTheFactSamplingBenchmarks.traceIdSampler                             1234567890987654321  thrpt   15  381.851 ± 12.185  ops/us

Benchmark                                                                            (traceId)   Mode  Cnt     Score    Error   Units
BeforeTheFactSamplingBenchmarks.compareCounter                            -9223372036854775808  thrpt   15   503.203 ± 15.877  ops/us
BeforeTheFactSamplingBenchmarks.compareCounter                             1234567890987654321  thrpt   15   492.021 ± 10.621  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                       -9223372036854775808  thrpt   15   349.221 ± 10.535  ops/us
BeforeTheFactSamplingBenchmarks.compareRandomNumber                        1234567890987654321  thrpt   15   357.286 ±  4.199  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted         -9223372036854775808  thrpt   15   862.019 ± 21.847  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_modulo10000_salted          1234567890987654321  thrpt   15   858.131 ± 16.858  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense  -9223372036854775808  thrpt   15  1296.479 ± 12.854  ops/us
BeforeTheFactSamplingBenchmarks.compareTraceId_mostNegativeNumberDefense   1234567890987654321  thrpt   15  1058.780 ±  9.621  ops/us
BeforeTheFactSamplingBenchmarks.traceIdSampler                            -9223372036854775808  thrpt   15  1294.338 ± 21.518  ops/us
BeforeTheFactSamplingBenchmarks.traceIdSampler                             1234567890987654321  thrpt   15  1222.360 ± 29.322  ops/us
```