### PR TITLE
Removes Closeable contract from SpanStore

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/SpanStore.java
@@ -14,11 +14,10 @@
 package io.zipkin;
 
 import io.zipkin.internal.Nullable;
-import java.io.Closeable;
 import java.util.Iterator;
 import java.util.List;
 
-public interface SpanStore extends Closeable {
+public interface SpanStore {
 
   /**
    * Sinks the given spans, ignoring duplicate annotations.
@@ -74,7 +73,4 @@ public interface SpanStore extends Closeable {
    *         found
    */
   List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback);
-
-  @Override
-  void close();
 }

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,7 +63,7 @@ public final class ScalaDependencyStoreAdapter extends com.twitter.zipkin.storag
 
   @Override
   public void close() {
-    this.spanStore.close();
+    // noop
   }
 
   private static DependencyLink convert(io.zipkin.DependencyLink input) {

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -106,7 +106,7 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
 
   @Override
   public void close() {
-    this.spanStore.close();
+    // noop
   }
 
   @Nullable

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
@@ -337,10 +337,6 @@ public final class JDBCSpanStore implements SpanStore {
         .fetchMap(r -> Pair.create(r.value1(), r.value2()), Record3::value3);
   }
 
-  @Override
-  public void close() {
-  }
-
   private static Endpoint endpoint(Record a) {
     String serviceName = a.getValue(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME);
     if (serviceName == null) {

--- a/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/InMemorySpanStore.java
@@ -104,10 +104,6 @@ public final class InMemorySpanStore implements SpanStore {
     return Collections.emptyList();
   }
 
-  @Override
-  public void close() {
-  }
-
   private static Predicate<List<Span>> spansPredicate(QueryRequest request) {
     return spans -> {
       Long timestamp = spans.get(0).timestamp;

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/TraceWritesSpanStore.java
@@ -90,9 +90,4 @@ public final class TraceWritesSpanStore implements SpanStore {
       tracer.finishSpan();
     }
   }
-
-  @Override
-  public void close() {
-    delegate.close();
-  }
 }


### PR DESCRIPTION
Closeable isn't the only way to close things, and in reality we weren't
doing anything with it. This punts the decision on how to close
resources to implementing types.

See https://github.com/openzipkin/zipkin/issues/584