### PR TITLE
Fixes imports per style and removes unnecessary "this" qualification

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/Annotation.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Annotation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -85,7 +85,7 @@ public final class Annotation implements Comparable<Annotation> {
     }
 
     public Annotation build() {
-      return Annotation.create(this.timestamp, this.value, this.endpoint);
+      return Annotation.create(timestamp, value, endpoint);
     }
   }
 

--- a/zipkin-java-core/src/main/java/io/zipkin/DependencyLink.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/DependencyLink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -68,7 +68,7 @@ public final class DependencyLink {
     }
 
     public DependencyLink build() {
-      return new DependencyLink(this.parent, this.child, this.callCount);
+      return new DependencyLink(parent, child, callCount);
     }
   }
 

--- a/zipkin-java-core/src/main/java/io/zipkin/Endpoint.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Endpoint.java
@@ -108,7 +108,7 @@ public final class Endpoint {
     }
 
     public Endpoint build() {
-      return new Endpoint(this.serviceName, this.ipv4, this.port);
+      return new Endpoint(serviceName, ipv4, port);
     }
   }
 

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaDependencyStoreAdapter.java
@@ -17,7 +17,6 @@ import com.twitter.util.Future;
 import com.twitter.zipkin.common.Dependencies;
 import com.twitter.zipkin.common.DependencyLink;
 import io.zipkin.SpanStore;
-import io.zipkin.internal.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import scala.Option;

--- a/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/zipkin-java-interop/src/main/java/io/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -69,14 +69,14 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
       Tuple2<String, String> keyValue = i.next();
       request.addBinaryAnnotation(keyValue._1(), keyValue._2());
     }
-    return toSeqFuture(this.spanStore.getTraces(request.build()));
+    return toSeqFuture(spanStore.getTraces(request.build()));
   }
 
   @Override
   public Future<Seq<List<Span>>> getTracesByIds(Seq<Object> input) {
     java.util.List<Long> traceIds = JavaConversions.asJavaCollection(input).stream()
         .map(o -> Long.valueOf(o.toString())).collect(toList());
-    return toSeqFuture(this.spanStore.getTracesByIds(traceIds));
+    return toSeqFuture(spanStore.getTracesByIds(traceIds));
   }
 
   private static Future<Seq<List<Span>>> toSeqFuture(java.util.List<java.util.List<io.zipkin.Span>> traces) {
@@ -90,17 +90,17 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
 
   @Override
   public Future<Seq<String>> getAllServiceNames() {
-    return Future.value(JavaConversions.asScalaBuffer(this.spanStore.getServiceNames()).seq());
+    return Future.value(JavaConversions.asScalaBuffer(spanStore.getServiceNames()).seq());
   }
 
   @Override
   public Future<Seq<String>> getSpanNames(String service) {
-    return Future.value(JavaConversions.asScalaBuffer(this.spanStore.getSpanNames(service)).seq());
+    return Future.value(JavaConversions.asScalaBuffer(spanStore.getSpanNames(service)).seq());
   }
 
   @Override
   public Future<BoxedUnit> apply(Seq<Span> input) {
-    this.spanStore.accept(ScalaSpanStoreAdapter.invert(input).iterator());
+    spanStore.accept(ScalaSpanStoreAdapter.invert(input).iterator());
     return Future.Unit();
   }
 

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/JDBCSpanStore.java
@@ -82,7 +82,7 @@ public final class JDBCSpanStore implements SpanStore {
   }
 
   void clear() throws SQLException {
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       context(conn).truncate(ZIPKIN_SPANS).execute();
       context(conn).truncate(ZIPKIN_ANNOTATIONS).execute();
     }
@@ -91,7 +91,7 @@ public final class JDBCSpanStore implements SpanStore {
   @Override
   public void accept(Iterator<Span> spans) {
     if (!spans.hasNext()) return;
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       DSLContext create = context(conn);
 
       List<Query> inserts = new ArrayList<>();
@@ -167,7 +167,7 @@ public final class JDBCSpanStore implements SpanStore {
   private List<List<Span>> getTraces(@Nullable QueryRequest request, @Nullable List<Long> traceIds) {
     final Map<Long, List<Span>> spansWithoutAnnotations;
     final Map<Pair<?>, List<Record>> dbAnnotations;
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       if (request != null) {
         traceIds = toTraceIdQuery(context(conn), request).fetch(ZIPKIN_SPANS.TRACE_ID);
       }
@@ -241,8 +241,8 @@ public final class JDBCSpanStore implements SpanStore {
     return DSL.using(new DefaultConfiguration()
         .set(conn)
         .set(JDBCUtils.dialect(conn))
-        .set(this.settings)
-        .set(this.listenerProvider));
+        .set(settings)
+        .set(listenerProvider));
   }
 
   @Override
@@ -252,7 +252,7 @@ public final class JDBCSpanStore implements SpanStore {
 
   @Override
   public List<String> getServiceNames() {
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       return context(conn)
           .selectDistinct(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME)
           .from(ZIPKIN_ANNOTATIONS)
@@ -268,7 +268,7 @@ public final class JDBCSpanStore implements SpanStore {
   public List<String> getSpanNames(String serviceName) {
     if (serviceName == null) return emptyList();
     serviceName = serviceName.toLowerCase(); // service names are always lowercase!
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       return context(conn)
           .selectDistinct(ZIPKIN_SPANS.NAME)
           .from(ZIPKIN_SPANS)
@@ -286,7 +286,7 @@ public final class JDBCSpanStore implements SpanStore {
   @Override
   public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
     endTs = endTs * 1000;
-    try (Connection conn = this.datasource.getConnection()) {
+    try (Connection conn = datasource.getConnection()) {
       Map<Long, List<Record3<Long, Long, Long>>> parentChild = context(conn)
           .select(ZIPKIN_SPANS.TRACE_ID, ZIPKIN_SPANS.PARENT_ID, ZIPKIN_SPANS.ID)
           .from(ZIPKIN_SPANS)

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/Tables.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/Tables.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,10 +16,8 @@
  */
 package io.zipkin.jdbc.internal.generated;
 
-
 import io.zipkin.jdbc.internal.generated.tables.ZipkinAnnotations;
 import io.zipkin.jdbc.internal.generated.tables.ZipkinSpans;
-
 import javax.annotation.Generated;
 
 

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/Zipkin.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/Zipkin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,16 +16,12 @@
  */
 package io.zipkin.jdbc.internal.generated;
 
-
 import io.zipkin.jdbc.internal.generated.tables.ZipkinAnnotations;
 import io.zipkin.jdbc.internal.generated.tables.ZipkinSpans;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import javax.annotation.Generated;
-
 import org.jooq.Table;
 import org.jooq.impl.SchemaImpl;
 

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinAnnotations.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinAnnotations.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,11 +16,8 @@
  */
 package io.zipkin.jdbc.internal.generated.tables;
 
-
 import io.zipkin.jdbc.internal.generated.Zipkin;
-
 import javax.annotation.Generated;
-
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Table;

--- a/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinSpans.java
+++ b/zipkin-java-jdbc/src/main/java/io/zipkin/jdbc/internal/generated/tables/ZipkinSpans.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,11 +16,8 @@
  */
 package io.zipkin.jdbc.internal.generated.tables;
 
-
 import io.zipkin.jdbc.internal.generated.Zipkin;
-
 import javax.annotation.Generated;
-
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Table;

--- a/zipkin-java-server/src/main/java/io/zipkin/server/EnableZipkinServer.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/EnableZipkinServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,15 +13,13 @@
  */
 package io.zipkin.server;
 
+import io.zipkin.server.brave.BraveConfiguration;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.springframework.context.annotation.Import;
-
-import io.zipkin.server.brave.BraveConfiguration;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinQueryApiV1.java
@@ -66,34 +66,34 @@ public class ZipkinQueryApiV1 {
   @RequestMapping(value = "/dependencies", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
   public byte[] getDependencies(@RequestParam(value = "endTs", required = true) long endTs,
                                 @RequestParam(value = "lookback", required = false) Long lookback) {
-    return this.jsonCodec.writeDependencyLinks(this.spanStore.getDependencies(endTs, lookback != null ? lookback : defaultLookback));
+    return jsonCodec.writeDependencyLinks(spanStore.getDependencies(endTs, lookback != null ? lookback : defaultLookback));
   }
 
   @RequestMapping(value = "/services", method = RequestMethod.GET)
   public List<String> getServiceNames() {
-    return this.spanStore.getServiceNames();
+    return spanStore.getServiceNames();
   }
 
   @RequestMapping(value = "/spans", method = RequestMethod.GET)
   public List<String> getSpanNames(
       @RequestParam(value = "serviceName", required = true) String serviceName) {
-    return this.spanStore.getSpanNames(serviceName);
+    return spanStore.getSpanNames(serviceName);
   }
 
   @RequestMapping(value = "/spans", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void uploadSpansJson(@RequestBody byte[] body) {
-    List<Span> spans = this.jsonCodec.readSpans(body);
+    List<Span> spans = jsonCodec.readSpans(body);
     if (spans == null) throw new MalformedSpansException(APPLICATION_JSON_VALUE);
-    this.spanWriter.write(this.spanStore, spans);
+    spanWriter.write(spanStore, spans);
   }
 
   @RequestMapping(value = "/spans", method = RequestMethod.POST, consumes = APPLICATION_THRIFT)
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void uploadSpansThrift(@RequestBody byte[] body) {
-    List<Span> spans = this.thriftCodec.readSpans(body);
+    List<Span> spans = thriftCodec.readSpans(body);
     if (spans == null) throw new MalformedSpansException(APPLICATION_THRIFT);
-    this.spanWriter.write(this.spanStore, spans);
+    spanWriter.write(spanStore, spans);
   }
 
   @RequestMapping(value = "/traces", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
@@ -127,19 +127,19 @@ public class ZipkinQueryApiV1 {
         }
       }
     }
-    return this.jsonCodec.writeTraces(this.spanStore.getTraces(builder.build()));
+    return jsonCodec.writeTraces(spanStore.getTraces(builder.build()));
   }
 
   @RequestMapping(value = "/trace/{traceId}", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
   public byte[] getTrace(@PathVariable String traceId) {
     @SuppressWarnings("resource")
     long id = new Buffer().writeUtf8(traceId).readHexadecimalUnsignedLong();
-    List<List<Span>> traces = this.spanStore.getTracesByIds(Collections.singletonList(id));
+    List<List<Span>> traces = spanStore.getTracesByIds(Collections.singletonList(id));
 
     if (traces.isEmpty()) {
       throw new TraceNotFoundException(traceId, id);
     }
-    return this.jsonCodec.writeSpans(traces.get(0));
+    return jsonCodec.writeSpans(traces.get(0));
   }
 
   @ExceptionHandler(TraceNotFoundException.class)

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinServerProperties.java
@@ -20,7 +20,7 @@ class ZipkinServerProperties {
   private Store store = new Store();
 
   public Store getStore() {
-    return this.store;
+    return store;
   }
 
   static class Store {
@@ -31,7 +31,7 @@ class ZipkinServerProperties {
     private Type type = Type.mem;
 
     public Type getType() {
-      return this.type;
+      return type;
     }
 
     public void setType(Type type) {

--- a/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinSpanWriter.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/ZipkinSpanWriter.java
@@ -35,7 +35,7 @@ public class ZipkinSpanWriter {
   public void write(SpanStore spanStore, List<Span> spans) {
     Iterator<Span> sampled = spans.stream()
         // For portability with zipkin v1, debug always wins.
-        .filter(s -> (s.debug != null && s.debug) || this.sampler.test(s.traceId))
+        .filter(s -> (s.debug != null && s.debug) || sampler.test(s.traceId))
         .iterator();
 
     spanStore.accept(sampled);

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/BraveConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,12 +13,15 @@
  */
 package io.zipkin.server.brave;
 
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerTracer;
+import io.zipkin.Endpoint;
+import io.zipkin.SpanStore;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Collections;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,12 +34,6 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerTracer;
-
-import io.zipkin.Endpoint;
-import io.zipkin.SpanStore;
-
 @Configuration
 @ConditionalOnClass(ServerTracer.class)
 @Import({ApiTracerConfiguration.class, JDBCTracerConfiguration.class})
@@ -44,11 +41,11 @@ import io.zipkin.SpanStore;
 public class BraveConfiguration {
 
   @Autowired
-  private SpanStoreSpanCollector spanCollector;
+  SpanStoreSpanCollector spanCollector;
 
   @Scheduled(fixedDelayString = "${zipkin.collector.delayMillisec:1000}")
   public void flushSpans() {
-    this.spanCollector.flush();
+    spanCollector.flush();
   }
 
   /** This gets the lanIP without trying to lookup its name. */

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/JDBCTracerConfiguration.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/JDBCTracerConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
@@ -62,22 +61,22 @@ public class JDBCTracerConfiguration extends DefaultExecuteListener {
   @Override
   public void renderEnd(ExecuteContext ctx) {
     if (ctx.type() == ExecuteType.READ) { // Don't log writes (so as to not loop on collector)
-      this.brave.clientTracer().startNewSpan("query");
-      this.brave.clientTracer().setCurrentClientServiceName("zipkin-query");
+      brave.clientTracer().startNewSpan("query");
+      brave.clientTracer().setCurrentClientServiceName("zipkin-query");
       String[] batchSQL = ctx.batchSQL();
       if (!StringUtils.isBlank(ctx.sql())) {
-        this.brave.clientTracer().submitBinaryAnnotation("jdbc.query", ctx.sql());
+        brave.clientTracer().submitBinaryAnnotation("jdbc.query", ctx.sql());
       } else if (batchSQL.length > 0 && batchSQL[batchSQL.length - 1] != null) {
-        this.brave.clientTracer().submitBinaryAnnotation("jdbc.query", StringUtils.join(batchSQL, '\n'));
+        brave.clientTracer().submitBinaryAnnotation("jdbc.query", StringUtils.join(batchSQL, '\n'));
       }
-      this.brave.clientTracer().setClientSent(jdbcEndpoint.ipv4, jdbcEndpoint.port, jdbcEndpoint.serviceName);
+      brave.clientTracer().setClientSent(jdbcEndpoint.ipv4, jdbcEndpoint.port, jdbcEndpoint.serviceName);
     }
   }
 
   @Override
   public void executeEnd(ExecuteContext ctx) {
     if (ctx.type() == ExecuteType.READ) { // Don't log writes (so as to not loop on collector)
-      this.brave.clientTracer().setClientReceived();
+      brave.clientTracer().setClientReceived();
     }
   }
 }

--- a/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-java-server/src/main/java/io/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -42,7 +42,7 @@ public class SpanStoreSpanCollector implements SpanCollector, Flushable {
   }
 
   public void collect(Span span) {
-    if (this.queue.offer(span) && this.queue.size() >= this.limit) {
+    if (queue.offer(span) && queue.size() >= limit) {
       flush();
     }
   }
@@ -54,15 +54,15 @@ public class SpanStoreSpanCollector implements SpanCollector, Flushable {
 
   @Override
   public void flush() {
-    List<Span> spans = new ArrayList<>(this.queue.size());
-    while (!this.queue.isEmpty()) {
-      Span span = this.queue.poll();
+    List<Span> spans = new ArrayList<>(queue.size());
+    while (!queue.isEmpty()) {
+      Span span = queue.poll();
       if (span != null) {
         spans.add(span);
       }
     }
     if (!spans.isEmpty()) {
-      this.spanStore.accept(spans.iterator());
+      spanStore.accept(spans.iterator());
     }
   }
 

--- a/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinServerIntegrationTests.java
+++ b/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinServerIntegrationTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,13 +45,13 @@ public class ZipkinServerIntegrationTests {
 
   @Before
   public void init() {
-    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
   }
 
   @Test
   public void writeSpans_noContentTypeIsJson() throws Exception {
     byte[] body = Codec.JSON.writeSpans(Arrays.asList(newSpan(1L, 1L, "foo", "an", "bar")));
-    this.mockMvc
+    mockMvc
         .perform(post("/api/v1/spans").content(body))
         .andExpect(status().isAccepted());
   }
@@ -59,7 +59,7 @@ public class ZipkinServerIntegrationTests {
   @Test
   public void writeSpans_malformedJsonIsBadRequest() throws Exception {
     byte[] body = {'h', 'e', 'l', 'l', 'o'};
-    this.mockMvc
+    mockMvc
         .perform(post("/api/v1/spans").content(body))
         .andExpect(status().isBadRequest());
   }
@@ -67,7 +67,7 @@ public class ZipkinServerIntegrationTests {
   @Test
   public void writeSpans_contentTypeXThrift() throws Exception {
     byte[] body = Codec.THRIFT.writeSpans(Arrays.asList(newSpan(1L, 2L, "foo", "an", "bar")));
-    this.mockMvc
+    mockMvc
         .perform(post("/api/v1/spans").content(body).contentType("application/x-thrift"))
         .andExpect(status().isAccepted());
   }
@@ -75,7 +75,7 @@ public class ZipkinServerIntegrationTests {
   @Test
   public void writeSpans_malformedThriftIsBadRequest() throws Exception {
     byte[] body = {'h', 'e', 'l', 'l', 'o'};
-    this.mockMvc
+    mockMvc
         .perform(post("/api/v1/spans").content(body).contentType("application/x-thrift"))
         .andExpect(status().isBadRequest());
   }


### PR DESCRIPTION
[Spring Framework style guide](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Code-Style) requires folks to always qualify fields
with `this.`. This project isn't a part of the spring framework, nor
derives it style from that.

Square and Google style (from which it derives) does not require such
qualification. I've contributed to projects from many orgs, and Spring
is the only place I've seen this. I don't think it is a stretch to call
this unconventional.

Unconventional is fine, when it improves the experience of development.
Writing much of the code in this codebase, I've found the unnecessary
qualification to cause quite the opposite. It is a cognitive break,
where I wonder what is special which requires this qualification? Other
times, it intrudes on readability, for example chaining with parameters
ends up with `this.` boilerplated throughout the calls. In other words,
the fluency is reduced. Minor, but this can make long chains worse, or
cause wrapping.

While I feel it wouldn't be in my place to ask for Spring to change its
style, including use of tabs and `this.` qualifications, I do think it
is reasonable to not bring this (no pun intended) here.

The result of reverting this change, if convention isn't valuable, will
at least be a more joyful experience for the primary contributor.