### PR TITLE
Removes null coersion in Codec in favor of IllegalArgumentException

### DIFF
--- a/zipkin-java-core/src/main/java/io/zipkin/Codec.java
+++ b/zipkin-java-core/src/main/java/io/zipkin/Codec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 The OpenZipkin Authors
+ * Copyright 2015-2016 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,31 +45,20 @@ public interface Codec {
     }
   };
 
-  /** Returns null if the span couldn't be decoded */
-  @Nullable
+  /** throws {@linkplain IllegalArgumentException} if the span couldn't be decoded */
   Span readSpan(byte[] bytes);
 
-  /** Returns null if the span couldn't be encoded */
-  @Nullable
   byte[] writeSpan(Span value);
 
-  /** Returns null if the spans couldn't be decoded */
-  @Nullable
+  /** throws {@linkplain IllegalArgumentException} if the spans couldn't be decoded */
   List<Span> readSpans(byte[] bytes);
 
-  /** Returns null if the spans couldn't be encoded */
-  @Nullable
   byte[] writeSpans(List<Span> value);
 
-  /** Returns null if the traces couldn't be encoded */
-  @Nullable
   byte[] writeTraces(List<List<Span>> value);
 
-  /** Returns null if the dependency links couldn't be decoded */
-  @Nullable
+  /** throws {@linkplain IllegalArgumentException} if the dependency links couldn't be decoded */
   List<DependencyLink> readDependencyLinks(byte[] bytes);
 
-  /** Returns null if the dependency links couldn't be encoded */
-  @Nullable
   byte[] writeDependencyLinks(List<DependencyLink> value);
 }

--- a/zipkin-java-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-java-server/src/main/resources/zipkin-server.yml
@@ -32,4 +32,4 @@ spring:
 # Example of how to log codec failures
 # logging:
 #     level:
-#         io.zipkin.internal: 'TRACE'
+#         io.zipkin.server.ZipkinQueryApiV1: 'FINE'

--- a/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinServerIntegrationTests.java
+++ b/zipkin-java-server/src/test/java/io/zipkin/server/ZipkinServerIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringApplicationConfiguration(classes = ZipkinServer.class)
@@ -61,7 +62,8 @@ public class ZipkinServerIntegrationTests {
     byte[] body = {'h', 'e', 'l', 'l', 'o'};
     mockMvc
         .perform(post("/api/v1/spans").content(body))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("Malformed reading List<Span> from json: hello"));
   }
 
   @Test
@@ -77,7 +79,8 @@ public class ZipkinServerIntegrationTests {
     byte[] body = {'h', 'e', 'l', 'l', 'o'};
     mockMvc
         .perform(post("/api/v1/spans").content(body).contentType("application/x-thrift"))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("Malformed reading List<Span> from TBinary: aGVsbG8="));
   }
 
   static Span newSpan(long traceId, long id, String spanName, String value, String service) {


### PR DESCRIPTION
When a codec is reading, it is from a byte array, so the only possiblity
of problems is malformed input. This uses IllegalArgumentException to
indicate something the user can fix.

Since all domain objects are locally defined in core, and validated at
construction time, any errors writing to a byte array are bugs. This
uses AssertionError to indicate a bug.

Before, we weren't sending an error message to the user. This sends a
single-line description back in the 400 response. It also moves logging
to the call-site (`ZipkinQueryApiV1`).

Example curl request with bad content:
```bash
$ curl -X POST http://localhost:9411/api/v1/spans -H 'Content-Type: application/x-thrift' -d'foobar'
Malformed reading List<Span> from TBinary: Zm9vYmFy
```

Fixes #66