### PR TITLE
Adds ZipkinRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
   <modules>
     <module>zipkin</module>
+    <module>zipkin-junit</module>
     <module>benchmarks</module>
     <module>interop</module>
     <module>zipkin-spanstores</module>
@@ -122,6 +123,12 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin</artifactId>
         <type>test-jar</type>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-junit</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/zipkin-junit/README.md
+++ b/zipkin-junit/README.md
@@ -1,0 +1,26 @@
+# zipkin-junit
+
+This contains `ZipkinRule`, a JUnit rule to spin-up a Zipkin server during tests.
+
+For example, you can write micro-integration tests like so:
+
+```java
+@Rule
+public ZipkinRule zipkin = new ZipkinRule();
+
+// Pretend we have a traced system under test
+TracedService service = new TracedService(zipkin.httpUrl(), ReportingMode.FLUSH_EVERY);
+
+@Test
+public void skipsReportingWhenNotSampled() throws IOException {
+  zipkin.storeSpans(asList(rootSpan));
+
+  // send a request to the instrumented server, telling it not to sample.
+  client.addHeader("X-B3-TraceId", rootSpan.traceId)
+        .addHeader("X-B3-SpanId", rootSpan.id)
+        .addHeader("X-B3-Sampled", 0).get(service.httpUrl());
+
+  // check that zipkin didn't receive any new data in that trace
+  assertThat(zipkin.getTraces()).containsOnly(asList(rootSpan));
+}
+```

--- a/zipkin-junit/pom.xml
+++ b/zipkin-junit/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.5.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-junit</artifactId>
+  <name>JUnit rule to spin-up a Zipkin server during tests</name>
+
+  <properties>
+    <mockwebserver.version>3.1.2</mockwebserver.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${mockwebserver.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import java.util.Collections;
+import java.util.List;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import zipkin.Codec;
+import zipkin.DependencyLink;
+import zipkin.InMemorySpanStore;
+import zipkin.QueryRequest;
+import zipkin.Span;
+import zipkin.internal.JsonCodec;
+
+final class ZipkinDispatcher extends Dispatcher {
+  private static final JsonCodec JSON_CODEC = new JsonCodec();
+  private final InMemorySpanStore store;
+  private final MockWebServer server;
+
+  ZipkinDispatcher(InMemorySpanStore store, MockWebServer server) {
+    this.store = store;
+    this.server = server;
+  }
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) {
+    HttpUrl url = server.url(request.getPath());
+    if (request.getMethod().equals("GET")) {
+      if (url.encodedPath().equals("/api/v1/services")) {
+        return jsonResponse(JSON_CODEC.writeStrings(store.getServiceNames()));
+      } else if (url.encodedPath().equals("/api/v1/spans")) {
+        String serviceName = url.queryParameter("serviceName");
+        return jsonResponse(JSON_CODEC.writeStrings(store.getSpanNames(serviceName)));
+      } else if (url.encodedPath().equals("/api/v1/dependencies")) {
+        Long endTs = maybeLong(url.queryParameter("endTs"));
+        Long lookback = maybeLong(url.queryParameter("lookback"));
+        List<DependencyLink> result = store.getDependencies(endTs, lookback);
+        return jsonResponse(JSON_CODEC.writeDependencyLinks(result));
+      } else if (url.encodedPath().equals("/api/v1/traces")) {
+        QueryRequest queryRequest = toQueryRequest(url);
+        return jsonResponse(JSON_CODEC.writeTraces(store.getTraces(queryRequest)));
+      } else if (url.encodedPath().startsWith("/api/v1/trace/")) {
+        String traceId = url.encodedPath().replace("/api/v1/trace/", "");
+        long id = new Buffer().writeUtf8(traceId).readHexadecimalUnsignedLong();
+        List<List<Span>> traces = store.getTracesByIds(Collections.singletonList(id));
+        if (!traces.isEmpty()) return jsonResponse(JSON_CODEC.writeSpans(traces.get(0)));
+      }
+    } else if (request.getMethod().equals("POST")) {
+      if (url.encodedPath().equals("/api/v1/spans")) {
+        String type = request.getHeader("Content-Type");
+        Codec codec = type != null && type.contains("/x-thrift") ? Codec.THRIFT : JSON_CODEC;
+        List<Span> spans = codec.readSpans(request.getBody().readByteArray());
+        store.accept(spans.iterator());
+        return new MockResponse().setResponseCode(202);
+      }
+    } else { // unsupported method
+      return new MockResponse().setResponseCode(405);
+    }
+    return new MockResponse().setResponseCode(404);
+  }
+
+  static QueryRequest toQueryRequest(HttpUrl url) {
+    return new QueryRequest.Builder(url.queryParameter("serviceName"))
+                           .spanName(url.queryParameter("spanName"))
+                           .parseAnnotationQuery(url.queryParameter("annotationQuery"))
+                           .minDuration(maybeLong(url.queryParameter("minDuration")))
+                           .maxDuration(maybeLong(url.queryParameter("maxDuration")))
+                           .endTs(maybeLong(url.queryParameter("endTs")))
+                           .lookback(maybeLong(url.queryParameter("lookback")))
+                           .limit(maybeInteger(url.queryParameter("limit"))).build();
+  }
+
+  static Long maybeLong(String input) {
+    return input != null ? Long.valueOf(input) : null;
+  }
+
+  static Integer maybeInteger(String input) {
+    return input != null ? Integer.valueOf(input) : null;
+  }
+
+  static MockResponse jsonResponse(byte[] content) {
+    return new MockResponse()
+        .addHeader("Content-Type", "application/json")
+        .setBody(new Buffer().write(content));
+  }
+}

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import java.io.IOException;
+import java.util.List;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import zipkin.InMemorySpanStore;
+import zipkin.Span;
+
+/**
+ * Starts up a local Zipkin server, listening for http requests on {@link #httpUrl}.
+ *
+ * <p>This can be used to test instrumentation. For example, you can POST spans directly to this
+ * server.
+ *
+ * See http://openzipkin.github.io/zipkin-api/#/
+ */
+public final class ZipkinRule implements TestRule {
+  private final InMemorySpanStore store = new InMemorySpanStore();
+  private final MockWebServer server = new MockWebServer();
+
+  public ZipkinRule() {
+    server.setDispatcher(new ZipkinDispatcher(store, server));
+  }
+
+  /** Use this to connect. The zipkin v1 interface will be under "/api/v1" */
+  public String httpUrl() {
+    return String.format("http://%s:%s", server.getHostName(), server.getPort());
+  }
+
+  /**
+   * Stores the given spans directly, to setup preconditions for a test.
+   *
+   * <p>For example, if you are testing what happens when instrumentation adds a child to a trace,
+   * you'd add the parent here.
+   */
+  public ZipkinRule storeSpans(Iterable<Span> spans) {
+    store.accept(spans.iterator());
+    return this;
+  }
+
+  /** Retrieves all traces this zipkin server has received. */
+  public List<List<Span>> getTraces() {
+    return store.getTracesByIds(store.traceIds());
+  }
+
+  /**
+   * Used to manually start the server.
+   *
+   * @param httpPort choose 0 to select an available port
+   */
+  public void start(int httpPort) throws IOException {
+    server.start(httpPort);
+  }
+
+  /** Used to manually stop the server. */
+  public void shutdown() throws IOException {
+    server.shutdown();
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return server.apply(base, description);
+  }
+}

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import zipkin.DependencyLink;
+import zipkin.QueryRequest;
+import zipkin.Span;
+import zipkin.SpanStore;
+import zipkin.internal.JsonCodec;
+import zipkin.internal.Nullable;
+
+/**
+ * Implements the span store interface by forwarding requests over http.
+ *
+ * <p>Intentionally synchronous to reuse span store tests as http interface tests.
+ */
+final class HttpSpanStore implements SpanStore {
+
+  private static final JsonCodec JSON_CODEC = new JsonCodec();
+  private final OkHttpClient client = new OkHttpClient();
+  private final HttpUrl baseUrl;
+
+  /**
+   * @param baseUrl Ex "http://localhost:9411"
+   */
+  HttpSpanStore(String baseUrl) {
+    this.baseUrl = HttpUrl.parse(baseUrl);
+  }
+
+  @Override
+  public void accept(Iterator<Span> spans) {
+    List<Span> copy = new ArrayList<>();
+    while (spans.hasNext()) copy.add(spans.next());
+    byte[] spansInJson = JSON_CODEC.writeSpans(copy);
+    call(new Request.Builder()
+        .url(baseUrl.resolve("/api/v1/spans"))
+        .post(RequestBody.create(MediaType.parse("application/json"), spansInJson)).build()
+    );
+  }
+
+  @Override
+  public List<List<Span>> getTraces(QueryRequest request) {
+    HttpUrl.Builder url = baseUrl.newBuilder("/api/v1/traces?serviceName=" + request.serviceName);
+    maybeAddQueryParam(url, "spanName", request.spanName);
+    maybeAddQueryParam(url, "annotationQuery", request.toAnnotationQuery());
+    maybeAddQueryParam(url, "minDuration", request.minDuration);
+    maybeAddQueryParam(url, "maxDuration", request.maxDuration);
+    maybeAddQueryParam(url, "endTs", request.endTs);
+    maybeAddQueryParam(url, "lookback", request.lookback);
+    maybeAddQueryParam(url, "limit", request.limit);
+    Response response = call(new Request.Builder().url(url.build()).build());
+    return JSON_CODEC.readTraces(responseBytes(response));
+  }
+
+  @Override
+  public List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
+    List<List<Span>> result = new ArrayList<>(traceIds.size());
+    for (Long id : traceIds) {
+      Response response = call(new Request.Builder()
+          .url(baseUrl.resolve(String.format("/api/v1/trace/%016x", id)))
+          .build());
+      if (response.code() != 404) {
+        result.add(JSON_CODEC.readSpans(responseBytes(response)));
+      }
+    }
+    Collections.sort(result, TRACE_DESCENDING);
+    return result;
+  }
+
+  private static final Comparator<List<Span>> TRACE_DESCENDING = new Comparator<List<Span>>() {
+    @Override
+    public int compare(List<Span> left, List<Span> right) {
+      return right.get(0).compareTo(left.get(0));
+    }
+  };
+
+  @Override
+  public List<String> getServiceNames() {
+    Response response = call(new Request.Builder()
+        .url(baseUrl.resolve("/api/v1/services")).build());
+    return JSON_CODEC.readStrings(responseBytes(response));
+  }
+
+  @Override
+  public List<String> getSpanNames(String serviceName) {
+    Response response = call(new Request.Builder()
+        .url(baseUrl.resolve("/api/v1/spans?serviceName=" + serviceName)).build());
+    return JSON_CODEC.readStrings(responseBytes(response));
+  }
+
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
+    HttpUrl.Builder url = baseUrl.newBuilder("/api/v1/dependencies?endTs=" + endTs);
+    if (lookback != null) url.addQueryParameter("lookback", lookback.toString());
+    Response response = call(new Request.Builder().url(url.build()).build());
+    return JSON_CODEC.readDependencyLinks(responseBytes(response));
+  }
+
+  private Response call(Request request) {
+    try {
+      return client.newCall(request).execute();
+    } catch (IOException e) {
+      throw new IllegalStateException(e.getMessage(), e);
+    }
+  }
+
+  private void maybeAddQueryParam(HttpUrl.Builder builder, String name, @Nullable Object value) {
+    if (value != null) builder.addQueryParameter(name, value.toString());
+  }
+
+  private byte[] responseBytes(Response response) {
+    if (response.code() != 200) throw new RuntimeException("unexpected response: " + response);
+    try {
+      return response.body().bytes();
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+}

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinDispatcherTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinDispatcherTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import okhttp3.HttpUrl;
+import org.junit.Test;
+import zipkin.QueryRequest;
+import zipkin.TraceKeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipkinDispatcherTest {
+
+  HttpUrl baseUrl = HttpUrl.parse("http://localhost:9411/api/v1/traces");
+
+  @Test
+  public void toQueryRequest() {
+    HttpUrl url = baseUrl.newBuilder()
+        .addQueryParameter("serviceName", "zipkin-web")
+        .addQueryParameter("spanName", "get")
+        .addQueryParameter("limit", "1000").build();
+
+    QueryRequest request = ZipkinDispatcher.toQueryRequest(url);
+
+    assertThat(request.serviceName).isEqualTo("zipkin-web");
+    assertThat(request.spanName).isEqualTo("get");
+    assertThat(request.limit).isEqualTo(1000);
+  }
+
+  @Test
+  public void toQueryRequest_parseAnnotations() {
+    HttpUrl url = baseUrl.newBuilder()
+        .addQueryParameter("serviceName", "zipkin-web")
+        .addQueryParameter("annotationQuery", "finagle.retry and finagle.timeout").build();
+
+    QueryRequest request = ZipkinDispatcher.toQueryRequest(url);
+
+    assertThat(request.annotations)
+        .containsExactly("finagle.retry", "finagle.timeout");
+  }
+
+  @Test
+  public void toQueryRequest_parseBinaryAnnotations() {
+    HttpUrl url = baseUrl.newBuilder()
+        .addQueryParameter("serviceName", "myService")
+        .addQueryParameter("annotationQuery", "http.status_code=500").build();
+
+    QueryRequest request = ZipkinDispatcher.toQueryRequest(url);
+
+    assertThat(request.binaryAnnotations)
+        .hasSize(1)
+        .containsEntry(TraceKeys.HTTP_STATUS_CODE, "500");
+  }
+
+  @Test
+  public void toQueryRequest_parseBinaryAnnotations_withSlash() {
+    HttpUrl url = baseUrl.newBuilder()
+        .addQueryParameter("serviceName", "myService")
+        .addQueryParameter("annotationQuery", "http.path=/sessions").build();
+
+    QueryRequest request = ZipkinDispatcher.toQueryRequest(url);
+
+    assertThat(request.binaryAnnotations)
+        .hasSize(1)
+        .containsEntry(TraceKeys.HTTP_PATH, "/sessions");
+  }
+}

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleDependenciesTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleDependenciesTest.java
@@ -11,15 +11,30 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin;
+package zipkin.junit;
 
-public class InMemorySpanStoreTest extends SpanStoreTest<InMemorySpanStore> {
-  public InMemorySpanStoreTest() {
-    store = new InMemorySpanStore();
+import java.util.List;
+import org.junit.Rule;
+import zipkin.DependenciesTest;
+import zipkin.Span;
+
+/** Tests the http interface of {@link ZipkinRule}. */
+public class ZipkinRuleDependenciesTest extends DependenciesTest<HttpSpanStore> {
+
+  @Rule
+  public ZipkinRule server = new ZipkinRule();
+
+  public ZipkinRuleDependenciesTest() {
+    store = new HttpSpanStore(server.httpUrl());
   }
 
   @Override
   public void clear() {
-    store.clear();
+    // no need.. the test rule does this
+  }
+
+  @Override
+  protected void processDependencies(List<Span> spans) {
+    store.accept(spans.iterator());
   }
 }

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleSpanStoreTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleSpanStoreTest.java
@@ -11,15 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin;
+package zipkin.junit;
 
-public class InMemorySpanStoreTest extends SpanStoreTest<InMemorySpanStore> {
-  public InMemorySpanStoreTest() {
-    store = new InMemorySpanStore();
+import org.junit.Rule;
+import zipkin.SpanStoreTest;
+
+/** Tests the http interface of {@link ZipkinRule}. */
+public class ZipkinRuleSpanStoreTest extends SpanStoreTest<HttpSpanStore> {
+
+  @Rule
+  public ZipkinRule server = new ZipkinRule();
+
+  public ZipkinRuleSpanStoreTest() {
+    store = new HttpSpanStore(server.httpUrl());
   }
 
   @Override
   public void clear() {
-    store.clear();
+    // no need.. the test rule does this
   }
 }

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Codec;
+import zipkin.Endpoint;
+import zipkin.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.SERVER_RECV;
+
+public class ZipkinRuleTest {
+
+  @Rule
+  public ZipkinRule zipkin = new ZipkinRule();
+
+  OkHttpClient client = new OkHttpClient();
+
+  String service = "web";
+  Endpoint endpoint = Endpoint.create(service, 127 << 24 | 1, 80);
+  Annotation ann = Annotation.create(System.currentTimeMillis() * 1000, SERVER_RECV, endpoint);
+  Span span = new Span.Builder().id(1L).traceId(1L).name("get").addAnnotation(ann).build();
+
+  @Test
+  public void getTraces_storedUsingHttp() throws IOException {
+    // write the span to the zipkin using http
+    byte[] spansInJson = Codec.JSON.writeSpans(asList(span));
+    Response postResponse = client.newCall(new Request.Builder()
+        .url(zipkin.httpUrl() + "/api/v1/spans")
+        .post(RequestBody.create(MediaType.parse("application/json"), spansInJson)).build()
+    ).execute();
+    assertThat(postResponse.code()).isEqualTo(202);
+
+    // read the traces directly
+    assertThat(zipkin.getTraces())
+        .extracting(t -> t.get(0).traceId) // get only the trace id
+        .containsOnly(span.traceId);
+  }
+
+  @Test
+  public void storeSpans_readbackHttp() throws IOException {
+    // write the span to zipkin directly
+    zipkin.storeSpans(asList(span));
+
+    // read trace id using the the http api
+    Response getResponse = client.newCall(new Request.Builder()
+        .url(String.format("%s/api/v1/trace/%016x", zipkin.httpUrl(), span.traceId)).build()
+    ).execute();
+    assertThat(getResponse.code()).isEqualTo(200);
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -119,28 +119,16 @@ public class ZipkinQueryApiV1 {
       @RequestParam(value = "endTs", required = false) Long endTs,
       @RequestParam(value = "lookback", required = false) Long lookback,
       @RequestParam(value = "limit", required = false) Integer limit) {
-    QueryRequest.Builder builder = new QueryRequest.Builder(serviceName)
-        .spanName(spanName.equals("all") ? null : spanName)
+    QueryRequest queryRequest = new QueryRequest.Builder(serviceName)
+        .spanName(spanName)
+        .parseAnnotationQuery(annotationQuery)
         .minDuration(minDuration)
         .maxDuration(maxDuration)
         .endTs(endTs)
         .lookback(lookback != null ? lookback : defaultLookback)
-        .limit(limit);
+        .limit(limit).build();
 
-    if (annotationQuery != null && !annotationQuery.isEmpty()) {
-      for (String ann : annotationQuery.split(" and ")) {
-        if (ann.indexOf('=') == -1) {
-          builder.addAnnotation(ann);
-        } else {
-          String[] keyValue = ann.split("=");
-          if (keyValue.length < 2 || keyValue[1] == null) {
-            builder.addAnnotation(ann);
-          }
-          builder.addBinaryAnnotation(keyValue[0], keyValue[1]);
-        }
-      }
-    }
-    return jsonCodec.writeTraces(spanStore.getTraces(builder.build()));
+    return jsonCodec.writeTraces(spanStore.getTraces(queryRequest));
   }
 
   @RequestMapping(value = "/trace/{traceId}", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)

--- a/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCDependenciesTest.java
+++ b/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCDependenciesTest.java
@@ -17,12 +17,11 @@ import java.sql.SQLException;
 import java.util.List;
 import zipkin.DependenciesTest;
 import zipkin.Span;
-import zipkin.SpanStoreTest;
 
 public class JDBCDependenciesTest extends DependenciesTest<JDBCSpanStore> {
 
   public JDBCDependenciesTest() throws SQLException {
-    super(new JDBCTestGraph().spanStore);
+    this.store = new JDBCTestGraph().spanStore;
   }
 
   @Override

--- a/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCSpanStoreTest.java
+++ b/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCSpanStoreTest.java
@@ -19,7 +19,7 @@ import zipkin.SpanStoreTest;
 public class JDBCSpanStoreTest extends SpanStoreTest<JDBCSpanStore> {
 
   public JDBCSpanStoreTest() throws SQLException {
-    super(new JDBCTestGraph().spanStore);
+    store = new JDBCTestGraph().spanStore;
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/InMemorySpanStore.java
@@ -31,6 +31,7 @@ import zipkin.internal.DependencyLinkSpan;
 import zipkin.internal.DependencyLinker;
 import zipkin.internal.MergeById;
 import zipkin.internal.Nullable;
+import zipkin.internal.Util;
 
 import static zipkin.internal.Util.sortedList;
 
@@ -56,7 +57,11 @@ public final class InMemorySpanStore implements SpanStore {
     }
   }
 
-  synchronized void clear() {
+  public synchronized List<Long> traceIds() {
+    return Util.sortedList(traceIdToSpans.keySet());
+  }
+
+  public synchronized void clear() {
     traceIdToSpans.clear();
     serviceToTraceIds.clear();
   }

--- a/zipkin/src/test/java/zipkin/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/DependenciesTest.java
@@ -33,11 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class DependenciesTest<T extends SpanStore> {
 
   /** Should maintain state between multiple calls within a test. */
-  protected final T store;
-
-  protected DependenciesTest(T store) {
-    this.store = store;
-  }
+  protected T store;
 
   /** Clears the span store between tests. */
   @Before

--- a/zipkin/src/test/java/zipkin/InMemoryDependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/InMemoryDependenciesTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class InMemoryDependenciesTest extends DependenciesTest<InMemorySpanStore> {
 
   public InMemoryDependenciesTest() {
-    super(new InMemorySpanStore());
+    this.store = new InMemorySpanStore();
   }
 
   @Override

--- a/zipkin/src/test/java/zipkin/QueryRequestTest.java
+++ b/zipkin/src/test/java/zipkin/QueryRequestTest.java
@@ -17,6 +17,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class QueryRequestTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -83,5 +85,30 @@ public class QueryRequestTest {
     thrown.expectMessage("limit should be positive: was 0");
 
     new QueryRequest.Builder("foo").limit(0).build();
+  }
+
+  @Test
+  public void annotationQueryRoundTrip() {
+    String annotationQuery = "http.method=GET and finagle.retry";
+
+    QueryRequest request =
+        new QueryRequest.Builder("security-service").parseAnnotationQuery(annotationQuery).build();
+
+    assertThat(request.binaryAnnotations)
+        .containsEntry("http.method", "GET")
+        .hasSize(1);
+    assertThat(request.annotations)
+        .containsExactly("finagle.retry");
+
+    assertThat(request.toAnnotationQuery())
+        .isEqualTo(annotationQuery);
+  }
+
+  @Test
+  public void toAnnotationQueryWhenNoInputIsNull() {
+    QueryRequest request = new QueryRequest.Builder("security-service").build();
+
+    assertThat(request.toAnnotationQuery())
+        .isNull();
   }
 }

--- a/zipkin/src/test/java/zipkin/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/SpanStoreTest.java
@@ -37,11 +37,7 @@ import static zipkin.Constants.LOCAL_COMPONENT;
 public abstract class SpanStoreTest<T extends SpanStore> {
 
   /** Should maintain state between multiple calls within a test. */
-  protected final T store;
-
-  protected SpanStoreTest(T store) {
-    this.store = store;
-  }
+  protected T store;
 
   /** Clears the span store between tests. */
   @Before

--- a/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
+++ b/zipkin/src/test/java/zipkin/internal/JsonCodecTest.java
@@ -13,14 +13,37 @@
  */
 package zipkin.internal;
 
-import zipkin.Codec;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
 import zipkin.CodecTest;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public final class JsonCodecTest extends CodecTest {
-  private final Codec codec = Codec.JSON;
+  private final JsonCodec codec = new JsonCodec();
 
   @Override
-  protected Codec codec() {
+  protected JsonCodec codec() {
     return codec;
+  }
+
+  @Test
+  public void tracesRoundTrip() throws IOException {
+    List<List<Span>> traces = asList(TestObjects.TRACE, TestObjects.TRACE);
+    byte[] bytes = codec().writeTraces(traces);
+    assertThat(codec().readTraces(bytes))
+        .isEqualTo(traces);
+  }
+
+  @Test
+  public void stringsRoundTrip() throws IOException {
+    List<String> strings = asList("foo", "bar", "baz");
+    byte[] bytes = codec().writeStrings(strings);
+    assertThat(codec().readStrings(bytes))
+        .isEqualTo(strings);
   }
 }


### PR DESCRIPTION
This adds ZipkinRule, a JUnit rule to spin-up a Zipkin server during tests. For example, you can write micro-integration tests like so:

```java
@Rule
public ZipkinRule zipkin = new ZipkinRule();

// Pretend we have a traced system under test
TracedService service = new TracedService(zipkin.httpUrl(), ReportingMode.FLUSH_EVERY);

@Test
public void skipsReportingWhenNotSampled() throws IOException {
  zipkin.storeSpans(asList(rootSpan));

  // send a request to the instrumented server, telling it not to sample.
  client.addHeader("X-B3-TraceId", rootSpan.traceId)
        .addHeader("X-B3-SpanId", rootSpan.id)
        .addHeader("X-B3-Sampled", 0).get(service.httpUrl());

  // check that zipkin didn't receive any new data in that trace
  assertThat(zipkin.getTraces()).containsOnly(asList(rootSpan));
}
```

Fixes #64