### PR TITLE
Adds HttpFailure and httpRequestCount to ZipkinRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <junit.version>4.12</junit.version>
     <assertj.version>3.3.0</assertj.version>
 
+    <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
     <maven-plugin.version>0.3.3</maven-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-source-plugin.version>2.4</maven-source-plugin.version>
@@ -236,6 +237,26 @@
         <plugin>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>${animal-sniffer-maven-plugin.version}</version>
+          <configuration>
+            <signature>
+              <groupId>org.codehaus.mojo.signature</groupId>
+              <artifactId>java17</artifactId>
+              <version>1.0</version>
+            </signature>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/zipkin-junit/README.md
+++ b/zipkin-junit/README.md
@@ -2,6 +2,9 @@
 
 This contains `ZipkinRule`, a JUnit rule to spin-up a Zipkin server during tests.
 
+Usage
+------
+
 For example, you can write micro-integration tests like so:
 
 ```java
@@ -22,5 +25,22 @@ public void skipsReportingWhenNotSampled() throws IOException {
 
   // check that zipkin didn't receive any new data in that trace
   assertThat(zipkin.getTraces()).containsOnly(asList(rootSpan));
+}
+```
+
+You can also simulate failures.
+
+For example, if you want to ensure your instrumentation doesn't retry on http 400.
+
+```java
+@Test
+public void doesntAttemptToRetryOn400() throws IOException {
+  zipkin.enqueueFailure(sendErrorResponse(400, "Invalid Format"));
+
+  reporter.record(span);
+  reporter.flush();
+
+  // check that we didn't retry on 400
+  assertThat(zipkin.httpRequestCount()).isEqualTo(1);
 }
 ```

--- a/zipkin-junit/pom.xml
+++ b/zipkin-junit/pom.xml
@@ -24,9 +24,12 @@
   </parent>
 
   <artifactId>zipkin-junit</artifactId>
-  <name>JUnit rule to spin-up a Zipkin server during tests</name>
+  <name>Zipkin JUnit</name>
+  <description>JUnit rule to spin-up a Zipkin server during tests</description>
 
   <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <mockwebserver.version>3.1.2</mockwebserver.version>
   </properties>
 
@@ -55,4 +58,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- Make sure Java 8 types and methods aren't used -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zipkin-junit/src/main/java/zipkin/junit/HttpFailure.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/HttpFailure.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.junit;
+
+import okhttp3.mockwebserver.MockResponse;
+
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_REQUEST_BODY;
+
+/**
+ * Instrumentation that uses the {@code POST /api/v1/spans} endpoint needs to survive failures.
+ * Besides simply not starting the zipkin server, you can enqueue failures like this to test edge
+ * cases. For example, that you log a failure when a 400 code is returned.
+ */
+public final class HttpFailure {
+
+  /** Ex a network partition occurs in the middle of the POST request */
+  public static HttpFailure disconnectDuringBody() {
+    return new HttpFailure(new MockResponse().setSocketPolicy(DISCONNECT_DURING_REQUEST_BODY));
+  }
+
+  /** Ex code 400 when the server cannot read the spans */
+  public static HttpFailure sendErrorResponse(int code, String body) {
+    return new HttpFailure(new MockResponse().setResponseCode(code).setBody(body));
+  }
+
+  /** Not exposed publicly in order to not leak okhttp3 types. */
+  final MockResponse response;
+
+  private HttpFailure(MockResponse response) {
+    this.response = response;
+  }
+}

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
   </properties>
 
   <dependencies>
@@ -47,10 +46,6 @@
       <plugin>
         <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
         <executions>
           <!-- Ensure main source tree compiles to Java 7 bytecode. -->
           <execution>
@@ -70,21 +65,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <!-- Use of okio, moshi, and libthrift are internal only -->
       <plugin>


### PR DESCRIPTION
For ZipkinRule to be effective in instrumentation tests, it needs to
inject failures. This adds failure patterns found in existing Brave and
spring-cloud-sleuth tests.