### PR TITLE
Supports /heath endpoint

### DIFF
--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -42,7 +42,9 @@ final class ZipkinDispatcher extends Dispatcher {
   public MockResponse dispatch(RecordedRequest request) {
     HttpUrl url = server.url(request.getPath());
     if (request.getMethod().equals("GET")) {
-      if (url.encodedPath().equals("/api/v1/services")) {
+      if (url.encodedPath().equals("/health")) {
+        return new MockResponse().setBody("OK\n");
+      } else if (url.encodedPath().equals("/api/v1/services")) {
         return jsonResponse(JSON_CODEC.writeStrings(store.getServiceNames()));
       } else if (url.encodedPath().equals("/api/v1/spans")) {
         String serviceName = url.queryParameter("serviceName");

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinRuleTest.java
@@ -56,6 +56,16 @@ public class ZipkinRuleTest {
   }
 
   @Test
+  public void healthIsOK() throws IOException {
+    Response getResponse = client.newCall(new Request.Builder()
+        .url(zipkin.httpUrl() +"/health").build()
+    ).execute();
+
+    assertThat(getResponse.code()).isEqualTo(200);
+    assertThat(getResponse.body().string()).isEqualTo("OK\n");
+  }
+
+  @Test
   public void storeSpans_readbackHttp() throws IOException {
     // write the span to zipkin directly
     zipkin.storeSpans(asList(span));

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 
+    <!-- zipkin requires exporting /health endpoint -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
     <!-- Trace api controller activity with Brave -->
     <dependency>
       <groupId>com.github.kristofa</groupId>

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTests.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTests.java
@@ -31,6 +31,7 @@ import zipkin.Endpoint;
 import zipkin.Span;
 
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,6 +83,13 @@ public class ZipkinServerIntegrationTests {
         .perform(post("/api/v1/spans").content(body).contentType("application/x-thrift"))
         .andExpect(status().isBadRequest())
         .andExpect(content().string(startsWith("Malformed reading List<Span> from TBinary: aGVsbG8=")));
+  }
+
+  @Test
+  public void healthIsOK() throws Exception {
+    mockMvc
+        .perform(get("/health"))
+        .andExpect(status().isOk());
   }
 
   static Span newSpan(long traceId, long id, String spanName, String value, String service) {


### PR DESCRIPTION
Adds a /health endpoint that returns actuator data or "OK" if the test server.

See https://github.com/openzipkin/zipkin/issues/997