### PR TITLE
Removes internal use of libthrift

### DIFF
--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -29,7 +29,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <zipkin-scala.version>1.33.2</zipkin-scala.version>
+    <!-- override scrooge's thrift version so we don't need to declare a twitter-specific repo -->
+    <libthrift.version>0.9.3</libthrift.version>
+    <zipkin-scala.version>1.34.0</zipkin-scala.version>
     <scalatest.version>2.2.5</scalatest.version>
   </properties>
 
@@ -49,6 +51,18 @@
       <groupId>io.zipkin</groupId>
       <artifactId>zipkin-common</artifactId>
       <version>${zipkin-scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-scrooge</artifactId>
+      <version>${zipkin-scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${libthrift.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <moshi.version>1.1.0</moshi.version>
     <okio.version>1.6.0</okio.version>
     <spring-boot.version>1.3.2.RELEASE</spring-boot.version>
-    <libthrift.version>0.9.3</libthrift.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 
@@ -167,18 +166,6 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.thrift</groupId>
-        <artifactId>libthrift</artifactId>
-        <version>${libthrift.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -35,10 +35,6 @@
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-    </dependency>
   </dependencies>
 
   <build>
@@ -66,7 +62,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
-      <!-- Use of okio, moshi, and libthrift are internal only -->
+      <!-- Use of okio and moshi are internal only -->
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -86,10 +82,6 @@
                 <relocation>
                   <pattern>com.squareup.moshi</pattern>
                   <shadedPattern>zipkin.internal.moshi</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.thrift</pattern>
-                  <shadedPattern>zipkin.internal.libthrift</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -256,9 +256,9 @@ public final class Span implements Comparable<Span> {
      *
      * @see Span#annotations
      */
-    public Builder annotations(Annotation... annotations) {
+    public Builder annotations(Collection<Annotation> annotations) {
       this.annotations.clear();
-      Collections.addAll(this.annotations, annotations);
+      this.annotations.addAll(annotations);
       return this;
     }
 
@@ -273,9 +273,9 @@ public final class Span implements Comparable<Span> {
      *
      * @see Span#binaryAnnotations
      */
-    public Builder binaryAnnotations(BinaryAnnotation... binaryAnnotations) {
+    public Builder binaryAnnotations(Collection<BinaryAnnotation> binaryAnnotations) {
       this.binaryAnnotations.clear();
-      Collections.addAll(this.binaryAnnotations, binaryAnnotations);
+      this.binaryAnnotations.addAll(binaryAnnotations);
       return this;
     }
 


### PR DESCRIPTION
This implements TBinaryProtocol directly in the ThriftCodec. By doing
the code, dependencies, and exceptions are simpler (as we are decoding
via a buffer not a network). This uses Okio Buffer, which also
simplified some code.

The payment was having to implement a couple utilities from libthrift,
namely the skip logic. Overall, the code is smaller and the binary
shrunk from 275k to 225k.