### PR TITLE
Accepts gzip-encoded spans in zipkin-server and ZipkinRule

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -13,11 +13,15 @@
  */
 package zipkin.internal;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import okio.Buffer;
+import okio.GzipSink;
+import okio.GzipSource;
 
 public final class Util {
   public static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -62,6 +66,21 @@ public final class Util {
     List<T> result = new ArrayList<>(input);
     Collections.sort(result);
     return Collections.unmodifiableList(result);
+  }
+
+  public static byte[] gzip(byte[] bytes) throws IOException {
+    Buffer sink = new Buffer();
+    GzipSink gzipSink = new GzipSink(sink);
+    gzipSink.write(new Buffer().write(bytes), bytes.length);
+    gzipSink.close();
+    return sink.readByteArray();
+  }
+
+  public static byte[] gunzip(byte[] bytes) throws IOException {
+    Buffer result = new Buffer();
+    GzipSource source = new GzipSource(new Buffer().write(bytes));
+    while (source.read(result, Integer.MAX_VALUE) != -1) ;
+    return result.readByteArray();
   }
 
   private Util() {

--- a/zipkin/src/test/java/zipkin/internal/UtilTest.java
+++ b/zipkin/src/test/java/zipkin/internal/UtilTest.java
@@ -13,11 +13,15 @@
  */
 package zipkin.internal;
 
+import java.io.IOException;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static zipkin.internal.Util.equal;
+import static zipkin.internal.Util.gunzip;
+import static zipkin.internal.Util.gzip;
 
 public class UtilTest {
   @Test
@@ -27,5 +31,11 @@ public class UtilTest {
     assertFalse(equal(null, "1"));
     assertFalse(equal("1", null));
     assertFalse(equal("1", "2"));
+  }
+
+  @Test
+  public void gzipTest() throws IOException {
+    assertThat(gunzip(gzip("hello".getBytes())))
+        .isEqualTo("hello".getBytes());
   }
 }


### PR DESCRIPTION
This supports spans posted with "Content-Encoding: gzip".

Some of this code can be removed when Spring Boot supports request
decompression. Currently, compression is limited to responses only.

Fixes #69