### PR TITLE
Compresses GET responses

### DIFF
--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -19,6 +19,8 @@ server:
   port: ${QUERY_PORT:9411}
   compression:
     enabled: true
+    # compresses any response over min-response-size (default is 2KiB)
+    mime-types: application/json
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver


### PR DESCRIPTION
We were missing a parameter that controls GET compression. With this
change, json responses will be compressed.

Note: In spring-boot, only responses over a threshold are gzipped:
`server.compression.min-response-size` defaults to 2KiB.