### PR TITLE
Adds codec methods needed for Cassandra compatibility

### DIFF
--- a/zipkin/src/main/java/zipkin/DependencyLink.java
+++ b/zipkin/src/main/java/zipkin/DependencyLink.java
@@ -29,7 +29,7 @@ public final class DependencyLink {
   /** child service name (callee) */
   public final String child;
 
-  /** calls made during the duration (in microseconds) of this link */
+  /** calls made during the duration (in milliseconds) of this link */
   public final long callCount;
 
   DependencyLink(String parent, String child, long callCount) {

--- a/zipkin/src/main/java/zipkin/internal/Dependencies.java
+++ b/zipkin/src/main/java/zipkin/internal/Dependencies.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import okio.Buffer;
+import zipkin.DependencyLink;
+
+import static zipkin.internal.ThriftCodec.DEPENDENCY_LINKS_ADAPTER;
+import static zipkin.internal.ThriftCodec.Field;
+import static zipkin.internal.ThriftCodec.TYPE_I64;
+import static zipkin.internal.ThriftCodec.TYPE_LIST;
+import static zipkin.internal.ThriftCodec.TYPE_STOP;
+import static zipkin.internal.ThriftCodec.ThriftAdapter;
+import static zipkin.internal.ThriftCodec.read;
+import static zipkin.internal.ThriftCodec.skip;
+import static zipkin.internal.ThriftCodec.write;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * Internal as only cassandra serializes the start and end timestamps along with link data, and
+ * those serialized timestamps are never read.
+ *
+ * @deprecated See https://github.com/openzipkin/zipkin/issues/1008
+ */
+@Deprecated
+public final class Dependencies {
+
+  /** Reads from bytes serialized in TBinaryProtocol */
+  public static Dependencies fromThrift(ByteBuffer bytes) {
+    return read(THRIFT_ADAPTER, bytes);
+  }
+
+  /** Writes the current instance in TBinaryProtocol */
+  public ByteBuffer toThrift() {
+    return ByteBuffer.wrap(write(THRIFT_ADAPTER, this));
+  }
+
+  public static Dependencies create(long startTs, long endTs, List<DependencyLink> links) {
+    return new Dependencies(startTs, endTs, links);
+  }
+
+  /** milliseconds from epoch */
+  public final long startTs;
+
+  /** milliseconds from epoch) */
+  public final long endTs;
+
+  /** link information for every dependent service */
+  public final List<DependencyLink> links;
+
+  Dependencies(long startTs, long endTs, List<DependencyLink> links) {
+    this.startTs = startTs;
+    this.endTs = endTs;
+    this.links = checkNotNull(links, "links");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof Dependencies) {
+      Dependencies that = (Dependencies) o;
+      return (this.startTs == that.startTs)
+          && (this.endTs == that.endTs)
+          && (this.links.equals(that.links));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= (startTs >>> 32) ^ startTs;
+    h *= 1000003;
+    h ^= (endTs >>> 32) ^ endTs;
+    h *= 1000003;
+    h ^= links.hashCode();
+    return h;
+  }
+
+  /** @deprecated See https://github.com/openzipkin/zipkin/issues/1008 */
+  @Deprecated
+  static final ThriftAdapter<Dependencies> THRIFT_ADAPTER = new ThriftAdapter<Dependencies>() {
+
+    final Field START_TS = new Field(TYPE_I64, 1);
+    final Field END_TS = new Field(TYPE_I64, 2);
+    final Field LINKS = new Field(TYPE_LIST, 3);
+
+    @Override
+    public Dependencies read(ByteBuffer bytes) {
+      long startTs = 0L;
+      long endTs = 0L;
+      List<DependencyLink> links = null;
+
+      Field field;
+
+      while (true) {
+        field = Field.read(bytes);
+        if (field.type == TYPE_STOP) break;
+
+        if (field.equals(START_TS)) {
+          startTs = bytes.getLong();
+        } else if (field.equals(END_TS)) {
+          endTs = bytes.getLong();
+        } else if (field.equals(LINKS)) {
+          links = DEPENDENCY_LINKS_ADAPTER.read(bytes);
+        } else {
+          skip(bytes, field.type);
+        }
+      }
+
+      return Dependencies.create(startTs, endTs, links);
+    }
+
+    @Override
+    public void write(Dependencies value, Buffer buffer) {
+
+      START_TS.write(buffer);
+      buffer.writeLong(value.startTs);
+
+      END_TS.write(buffer);
+      buffer.writeLong(value.endTs);
+
+      LINKS.write(buffer);
+      DEPENDENCY_LINKS_ADAPTER.write(value.links, buffer);
+
+      buffer.writeByte(TYPE_STOP);
+    }
+
+    @Override
+    public String toString() {
+      return "Dependencies";
+    }
+  };
+}

--- a/zipkin/src/test/java/zipkin/internal/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependenciesTest.java
@@ -15,42 +15,24 @@ package zipkin.internal;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 import org.junit.Test;
-import zipkin.Codec;
-import zipkin.CodecTest;
 import zipkin.DependencyLink;
-import zipkin.Span;
-import zipkin.TestObjects;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class ThriftCodecTest extends CodecTest {
-  private final ThriftCodec codec = new ThriftCodec();
-
-  @Override
-  protected ThriftCodec codec() {
-    return codec;
-  }
-
+public final class DependenciesTest {
   @Test
-  public void readSpanFromByteBuffer() throws IOException {
-    for (Span span : TestObjects.TRACE) {
-      byte[] bytes = codec().writeSpan(span);
-      assertThat(codec().readSpan(ByteBuffer.wrap(bytes)))
-          .isEqualTo(span);
-    }
-  }
-
-  @Test
-  public void readDependencyLinksFromByteBuffer() throws IOException {
-    List<DependencyLink> links = asList(
+  public void dependenciesRoundTrip() throws IOException {
+    Dependencies dependencies = Dependencies.create(1L, 2L, asList(
         DependencyLink.create("foo", "bar", 2),
         DependencyLink.create("bar", "baz", 3)
-    );
-    byte[] bytes = codec().writeDependencyLinks(links);
-    assertThat(codec().readDependencyLinks(ByteBuffer.wrap(bytes)))
-        .isEqualTo(links);
+    ));
+
+    ByteBuffer bytes = dependencies.toThrift();
+    assertThat(Dependencies.fromThrift(bytes))
+        .isEqualTo(dependencies);
+
+    assertThat(bytes.remaining()).isZero();
   }
 }


### PR DESCRIPTION
This adds thrift read methods that accept ByteBuffers. This is in
support of the underlying DataStax Cassandra driver, which returns data
in ByteBuffers. The implementation takes care not to re-buffer input
data.

This also introduces an internal type, Dependencies, which is only used
in cassandra: https://github.com/openzipkin/zipkin/issues/1008

See #89