### PR TITLE
Adds ZipkinRule.receivedSpanCount and ZipkinRule.receivedSpanBytes

### DIFF
--- a/zipkin-junit/README.md
+++ b/zipkin-junit/README.md
@@ -2,6 +2,10 @@
 
 This contains `ZipkinRule`, a JUnit rule to spin-up a Zipkin server during tests.
 
+ZipkinRule aims to emulate a full-featured server. For example, it presents the
+entire [Zipkin Api](http://openzipkin.github.io/zipkin-api/#/), and supports
+features like gzip compression.
+
 Usage
 ------
 
@@ -44,3 +48,12 @@ public void doesntAttemptToRetryOn400() throws IOException {
   assertThat(zipkin.httpRequestCount()).isEqualTo(1);
 }
 ```
+
+Besides `httpRequestCount()`, there are two other counters that can
+help you assert instrumentation is doing what you think:
+
+* `receivedSpanCount()` - How many spans the server received.
+* `receivedSpanBytes()` - The cumulative bytes the server received.
+
+These counters can validate aspects such as compression or that you are
+grouping spans by id before reporting them to the server.

--- a/zipkin/src/main/java/zipkin/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/InMemorySpanStore.java
@@ -41,6 +41,7 @@ public final class InMemorySpanStore implements SpanStore {
   private final Multimap<Long, Span> traceIdToSpans = new LinkedListMultimap<>();
   private final Multimap<String, Long> serviceToTraceIds = new LinkedHashSetMultimap<>();
   private final Multimap<String, String> serviceToSpanNames = new LinkedHashSetMultimap<>();
+  private int acceptedSpanCount;
 
   @Override
   public synchronized void accept(Iterator<Span> spans) {
@@ -49,12 +50,17 @@ public final class InMemorySpanStore implements SpanStore {
       long traceId = span.traceId;
       String spanName = span.name;
       traceIdToSpans.put(span.traceId, span);
+      acceptedSpanCount++;
 
       for (String serviceName : serviceNames(span)) {
         serviceToTraceIds.put(serviceName, traceId);
         serviceToSpanNames.put(serviceName, spanName);
       }
     }
+  }
+
+  public synchronized int acceptedSpanCount() {
+    return acceptedSpanCount;
   }
 
   public synchronized List<Long> traceIds() {


### PR DESCRIPTION
This adds ZipkinRule.receivedSpanCount and ZipkinRule.receivedSpanBytes
to help instrumentation projects tune the amount of data they report.

Using this, instrumentation projects can verify they are sending less
bytes, ex via compression or less data duplication. They can also verify
they aren't sending more spans they expect. For example, instrumentation
can easily bundle the same span multiple times in the same POST request.