### PR TITLE
Adds CassandraSpanStore including zipkin-server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _site/
 .idea
 *.iml
 *.swp
+# .travis.yml installs cassandra in the pwd
+dsc-cassandra-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ services:
   - mysql
 
 before_install:
+  # Manually install cassandra until https://github.com/travis-ci/travis-ci/issues/3952
+  # See https://github.com/openzipkin/zipkin/issues/706
+  - curl -SL http://downloads.datastax.com/community/dsc-cassandra-2.2.3-bin.tar.gz | tar xz
+  - dsc-cassandra-*/bin/cassandra > /dev/null
+  # install mysql schema
   - mysql -uroot -e 'SET GLOBAL innodb_file_format=Barracuda'
   - mysql -utravis -e 'create database if not exists zipkin'
   - mysql -utravis -Dzipkin < zipkin-spanstores/jdbc/src/main/resources/mysql.sql

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin) [![Build Status](https://travis-ci.org/openzipkin/zipkin-java.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin-java) [![Download](https://api.bintray.com/packages/openzipkin/maven/zipkin-java/images/download.svg) ](https://bintray.com/openzipkin/maven/zipkin-java/_latestVersion)
 
 # zipkin-java
-This project is a native java port of [zipkin](https://github.com/openzipkin/zipkin), which was historically written in scala+finagle. This includes a dependency-free library and a [spring-boot](http://projects.spring.io/spring-boot/) replacement for zipkin's query server. Storage options are currently limited to in-memory and JDBC (mysql), but Cassandra support is expected soon.
+This project is a native java port of [zipkin](https://github.com/openzipkin/zipkin), which was historically written in scala+finagle. This includes a dependency-free library and a [spring-boot](http://projects.spring.io/spring-boot/) replacement for zipkin's query server. Storage options include in-memory, JDBC (mysql) and Cassandra.
 
 ## Library
 The [core library](https://github.com/openzipkin/zipkin-java/tree/master/zipkin/src/main/java/io/zipkin) requires minimum language level 7. While currently only used by the server, we expect this library to be used in native instrumentation as well.
@@ -18,7 +18,7 @@ span = new Span.Builder()
     .id(1L)
     .timestamp(epochMicros())
     .duration(durationInMicros)
-    .binaryAnnotations(archiver);
+    .addBinaryAnnotation(archiver);
 
 // Now, you can encode it as json or thrift
 bytes = Codec.JSON.writeSpan(span);

--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -31,7 +31,6 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- override scrooge's thrift version so we don't need to declare a twitter-specific repo -->
     <libthrift.version>0.9.3</libthrift.version>
-    <zipkin-scala.version>1.35.0</zipkin-scala.version>
     <scalatest.version>2.2.5</scalatest.version>
   </properties>
 
@@ -63,6 +62,12 @@
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>${libthrift.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spanstore-cassandra</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/interop/src/test/java/zipkin/cassandra/CassandraScalaDependencyStoreTest.java
+++ b/interop/src/test/java/zipkin/cassandra/CassandraScalaDependencyStoreTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.google.common.util.concurrent.Futures;
+import com.twitter.zipkin.common.Span;
+import com.twitter.zipkin.storage.DependencyStore;
+import com.twitter.zipkin.storage.DependencyStoreSpec;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.junit.BeforeClass;
+import scala.collection.immutable.List;
+import zipkin.DependencyLink;
+import zipkin.InMemorySpanStore;
+import zipkin.SpanStore;
+import zipkin.internal.Dependencies;
+import zipkin.interop.ScalaDependencyStoreAdapter;
+import zipkin.interop.ScalaSpanStoreAdapter;
+
+import static zipkin.internal.Util.midnightUTC;
+
+public class CassandraScalaDependencyStoreTest extends DependencyStoreSpec {
+  private static CassandraSpanStore spanStore;
+
+  @BeforeClass
+  public static void setupDB() {
+    spanStore = CassandraTestGraph.INSTANCE.spanStore();
+  }
+
+  public DependencyStore store() {
+    return new ScalaDependencyStoreAdapter(spanStore);
+  }
+
+  @Override
+  public void processDependencies(List<Span> input) {
+    SpanStore mem = new InMemorySpanStore();
+    new ScalaSpanStoreAdapter(mem).apply(input);
+    java.util.List<DependencyLink>
+        links = mem.getDependencies(today() + TimeUnit.DAYS.toMillis(1), null);
+
+    long midnight = midnightUTC(((long) input.apply(0).timestamp().get()) / 1000);
+    Dependencies deps = Dependencies.create(midnight, midnight /* ignored */, links);
+    ByteBuffer thrift = deps.toThrift();
+    // Block on the future to get read-your-writes consistency during tests
+    Futures.getUnchecked(spanStore.repository.storeDependencies(midnight, thrift));
+  }
+
+  public void clear() {
+    spanStore.clear();
+  }
+}

--- a/interop/src/test/java/zipkin/cassandra/CassandraScalaSpanStoreTest.java
+++ b/interop/src/test/java/zipkin/cassandra/CassandraScalaSpanStoreTest.java
@@ -11,31 +11,26 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.server;
+package zipkin.cassandra;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import com.twitter.zipkin.storage.SpanStore;
+import com.twitter.zipkin.storage.SpanStoreSpec;
+import org.junit.BeforeClass;
+import zipkin.interop.ScalaSpanStoreAdapter;
 
-@ConfigurationProperties("zipkin")
-class ZipkinServerProperties {
-  private Store store = new Store();
+public class CassandraScalaSpanStoreTest extends SpanStoreSpec {
+  private static CassandraSpanStore spanStore;
 
-  public Store getStore() {
-    return store;
+  @BeforeClass
+  public static void setupDB() {
+    spanStore = CassandraTestGraph.INSTANCE.spanStore();
   }
 
-  static class Store {
-    enum Type {
-      cassandra, mysql, mem
-    }
+  public SpanStore store() {
+    return new ScalaSpanStoreAdapter(spanStore);
+  }
 
-    private Type type = Type.mem;
-
-    public Type getType() {
-      return type;
-    }
-
-    public void setType(Type type) {
-      this.type = type;
-    }
+  public void clear() {
+    spanStore.clear();
   }
 }

--- a/interop/src/test/java/zipkin/cassandra/CassandraTestGraph.java
+++ b/interop/src/test/java/zipkin/cassandra/CassandraTestGraph.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.junit.AssumptionViolatedException;
+
+enum CassandraTestGraph {
+  INSTANCE;
+
+  private static final CassandraConfig CONFIG = new CassandraConfig.Builder()
+      .keyspace("test_zipkin_spanstore").build();
+
+  static {
+    // Avoid race-conditions in travis by forcing read-your-writes consistency.
+    CassandraSpanConsumer.BLOCK_ON_FUTURES = true;
+    // Ensure the repository's local cache of service names expire quickly
+    System.setProperty("zipkin.store.cassandra.internal.writtenNamesTtl", "1");
+  }
+
+  private AssumptionViolatedException ex;
+  private CassandraSpanStore spanStore;
+
+  /** A lot of tech debt here because the repository constructor performs I/O. */
+  synchronized CassandraSpanStore spanStore() {
+    if (ex != null) throw ex;
+    if (this.spanStore == null) {
+      try {
+        this.spanStore = new CassandraSpanStore(CONFIG);
+      } catch (NoHostAvailableException e) {
+        throw ex = new AssumptionViolatedException(e.getMessage());
+      }
+    }
+    return spanStore;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <moshi.version>1.1.0</moshi.version>
     <okio.version>1.6.0</okio.version>
     <spring-boot.version>1.3.2.RELEASE</spring-boot.version>
+    <zipkin-scala.version>1.35.0</zipkin-scala.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
 
@@ -129,6 +130,12 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-junit</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>spanstore-cassandra</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -275,6 +282,7 @@
             <exclude>**/.idea/**</exclude>
             <exclude>LICENSE</exclude>
             <exclude>**/*.md</exclude>
+            <exclude>dsc-cassandra-*/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>
           </excludes>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -21,6 +21,22 @@ The following environment variables from zipkin-scala are honored.
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem` or `mysql`
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
+### Cassandra
+The following apply when `STORAGE_TYPE` is set to `cassandra`:
+
+    * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
+    * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster. Defaults to localhost
+    * `CASSANDRA_LOCAL_DC`: Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+    * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
+    * `CASSANDRA_ENSURE_SCHEMA`: Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt. Defaults to true
+    * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
+
+Example usage:
+
+```bash
+$ STORAGE_TYPE=cassandra CASSANDRA_CONTACT_POINTS=host1,host2 ./mvnw -pl zipkin-server spring-boot:run
+```
+
 ### MySQL
 The following apply when `STORAGE_TYPE` is set to `mysql`:
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -90,6 +90,12 @@
       <artifactId>zipkin</artifactId>
     </dependency>
 
+    <!-- Cassandra backend -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spanstore-cassandra</artifactId>
+    </dependency>
+
     <!-- JDBC backend -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cassandra")
+class ZipkinCassandraProperties {
+  private String keyspace = "zipkin";
+  private String contactPoints = "localhost";
+  private String localDc;
+  private int maxConnections = 8;
+  private boolean ensureSchema = true;
+  private String username;
+  private String password;
+
+  public String getKeyspace() {
+    return keyspace;
+  }
+
+  public void setKeyspace(String keyspace) {
+    this.keyspace = keyspace;
+  }
+
+  public String getContactPoints() {
+    return contactPoints;
+  }
+
+  public void setContactPoints(String contactPoints) {
+    this.contactPoints = contactPoints;
+  }
+
+  public String getLocalDc() {
+    return localDc;
+  }
+
+  public void setLocalDc(String localDc) {
+    this.localDc = "".equals(localDc) ? null : localDc;
+  }
+
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+
+  public void setMaxConnections(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  public boolean isEnsureSchema() {
+    return ensureSchema;
+  }
+
+  public void setEnsureSchema(boolean ensureSchema) {
+    this.ensureSchema = ensureSchema;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = "".equals(username) ? null : username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = "".equals(password) ? null : password;
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
@@ -24,17 +24,16 @@ import org.jooq.ExecuteType;
 import org.jooq.impl.DefaultExecuteListener;
 import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.jooq.tools.StringUtils;
-import org.mariadb.jdbc.Driver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import zipkin.Endpoint;
 
 /** Sets up the JDBC tracing in Brave as an initialization. */
-@ConditionalOnClass({Driver.class})
+@ConditionalOnProperty(name = "zipkin.store.type", havingValue = "mysql")
 @Configuration
 public class JDBCTracerConfiguration extends DefaultExecuteListener {
 

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -1,6 +1,19 @@
+cassandra:
+  # Comma separated list of hosts / ip addresses part of Cassandra cluster.
+  contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
+  # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+  local-dc: ${CASSANDRA_LOCAL_DC:}
+  # Will throw an exception on startup if authentication fails.
+  username: ${CASSANDRA_USERNAME:}
+  password: ${CASSANDRA_PASSWORD:}
+  keyspace: ${CASSANDRA_KEYSPACE:zipkin}
+  # Max pooled connections per datacenter-local host.
+  max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
+  # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
+  ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
 mysql:
   host: ${MYSQL_HOST:localhost}
-  lookback: ${MYSQL_TCP_PORT:3306}
+  port: ${MYSQL_TCP_PORT:3306}
   username: ${MYSQL_USER:}
   password: ${MYSQL_PASS:}
   db: ${MYSQL_DB:zipkin}
@@ -24,7 +37,7 @@ server:
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mysql://${mysql.host}:${mysql.lookback}/${mysql.db}?autoReconnect=true&useSSL=${mysql.use-ssl}
+    url: jdbc:mysql://${mysql.host}:${mysql.port}/${mysql.db}?autoReconnect=true&useSSL=${mysql.use-ssl}
     username: ${mysql.username}
     password: ${mysql.password}
     max-active: ${mysql.max-active}

--- a/zipkin-spanstores/cassandra/README.md
+++ b/zipkin-spanstores/cassandra/README.md
@@ -1,0 +1,7 @@
+# spanstore-cassandra
+
+This is a CQL-based Cassandra 2.1+ SpanStore, compatible with [zipkin-scala](https://github.com/openzipkin/zipkin/tree/master/zipkin-cassandra).
+
+`zipkin.cassandra.CassandraConfig` includes defaults that will operate
+against a local Cassandra installation.
+

--- a/zipkin-spanstores/cassandra/pom.xml
+++ b/zipkin-spanstores/cassandra/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>zipkin-spanstores</artifactId>
+    <version>0.6.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>spanstore-cassandra</artifactId>
+  <name>SpanStore: Cassandra</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <mockito.version>1.10.19</mockito.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <!-- for org.twitter.zipkin.storage.cassandra.Repository -->
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-cassandra-core</artifactId>
+      <version>${zipkin-scala.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- To test nuance of load balancing behavior -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy;
+import zipkin.internal.Nullable;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/** Configuration including defaults needed to run against a local Cassandra installation. */
+public final class CassandraConfig {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String keyspace = "zipkin";
+    private String contactPoints = "localhost";
+    private String localDc;
+    private int maxConnections = 8;
+    private boolean ensureSchema = true;
+    private String username;
+    private String password;
+    private int maxTraceCols = 100000;
+    private int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
+    private int indexTtl = (int) TimeUnit.DAYS.toSeconds(3);
+
+    /** Keyspace to store span and index data. Defaults to "zipkin" */
+    public Builder keyspace(String keyspace) {
+      this.keyspace = keyspace;
+      return this;
+    }
+
+    /** Comma separated list of hosts / IPs part of Cassandra cluster. Defaults to localhost */
+    public Builder contactPoints(String contactPoints) {
+      this.contactPoints = contactPoints;
+      return this;
+    }
+
+    /**
+     * Name of the datacenter that will be considered "local" for latency load balancing. When
+     * unset, load-balancing is round-robin.
+     */
+    public Builder localDc(@Nullable String localDc) {
+      this.localDc = localDc;
+      return this;
+    }
+
+    /** Max pooled connections per datacenter-local host. Defaults to 8 */
+    public Builder maxConnections(int maxConnections) {
+      this.maxConnections = maxConnections;
+      return this;
+    }
+
+    /**
+     * Ensures that schema exists, if enabled tries to execute script
+     * io.zipkin:zipkin-cassandra-core/cassandra-schema-cql3.txt. Defaults to true.
+     */
+    public Builder ensureSchema(boolean ensureSchema) {
+      this.ensureSchema = ensureSchema;
+      return this;
+    }
+
+    /** Will throw an exception on startup if authentication fails. No default. */
+    public Builder username(@Nullable String username) {
+      this.username = username;
+      return this;
+    }
+
+    /** Will throw an exception on startup if authentication fails. No default. */
+    public Builder password(@Nullable String password) {
+      this.password = password;
+      return this;
+    }
+
+    /**
+     * Spans have multiple values for the same id. For example, a client and server contribute to
+     * the same span id. When searching for spans by id, the amount of results may be larger than
+     * the ids. This defines a threshold which accommodates this situation, without looking for an
+     * unbounded number of results.
+     */
+    public Builder maxTraceCols(int maxTraceCols) {
+      this.maxTraceCols = maxTraceCols;
+      return this;
+    }
+
+    /** Time-to-live in seconds for index data. Defaults to 3 days */
+    public Builder indexTtl(int indexTtl) {
+      this.indexTtl = indexTtl;
+      return this;
+    }
+
+    /** Time-to-live in seconds for span data. Defaults to 7 days */
+    public Builder spanTtl(int spanTtl) {
+      this.spanTtl = spanTtl;
+      return this;
+    }
+
+    public CassandraConfig build() {
+      return new CassandraConfig(this);
+    }
+  }
+
+  final String keyspace;
+  final int maxTraceCols;
+  final int indexTtl;
+  final int spanTtl;
+  final String contactPoints;
+  final int maxConnections;
+  final boolean ensureSchema;
+  final String localDc;
+  final String username;
+  final String password;
+
+  private CassandraConfig(Builder builder) {
+    this.keyspace = checkNotNull(builder.keyspace, "keyspace");
+    this.maxTraceCols = builder.maxTraceCols;
+    this.indexTtl = builder.indexTtl;
+    this.spanTtl = builder.spanTtl;
+    this.contactPoints = checkNotNull(builder.contactPoints, "contactPoints");
+    this.maxConnections = builder.maxConnections;
+    this.ensureSchema = builder.ensureSchema;
+    this.localDc = builder.localDc;
+    this.username = builder.username;
+    this.password = builder.password;
+  }
+
+  Cluster toCluster() {
+    Cluster.Builder builder = Cluster.builder();
+    List<InetSocketAddress> contactPoints = parseContactPoints();
+    int defaultPort = findConnectPort(contactPoints);
+    builder.addContactPointsWithPorts(contactPoints);
+    builder.withPort(defaultPort); // This ends up protocolOptions.port
+    if (username != null && password != null) {
+      builder.withCredentials(username, password);
+    }
+    builder.withRetryPolicy(ZipkinRetryPolicy.INSTANCE);
+    builder.withLoadBalancingPolicy(new TokenAwarePolicy(new LatencyAwarePolicy.Builder(
+        localDc != null
+            ? DCAwareRoundRobinPolicy.builder().withLocalDc(localDc).build()
+            : DCAwareRoundRobinPolicy.builder().build()
+    ).build()));
+    builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
+        HostDistance.LOCAL, maxConnections
+    ));
+    return builder.build();
+  }
+
+  List<InetSocketAddress> parseContactPoints() {
+    List<InetSocketAddress> result = new LinkedList<>();
+    for (String contactPoint : contactPoints.split(",")) {
+      HostAndPort parsed = HostAndPort.fromString(contactPoint);
+      result.add(
+          new InetSocketAddress(parsed.getHostText(), parsed.getPortOrDefault(9042)));
+    }
+    return result;
+  }
+
+  /** Returns the consistent port across all contact points or 9042 */
+  static int findConnectPort(List<InetSocketAddress> contactPoints) {
+    Set<Integer> ports = Sets.newLinkedHashSet();
+    for (InetSocketAddress contactPoint : contactPoints) {
+      ports.add(contactPoint.getPort());
+    }
+    return ports.size() == 1 ? ports.iterator().next() : 9042;
+  }
+}

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanConsumer.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanConsumer.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.twitter.zipkin.storage.cassandra.Repository;
+import zipkin.Span;
+import zipkin.SpanStore;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.internal.ThriftCodec;
+
+import static zipkin.cassandra.CassandraUtil.annotationKeys;
+
+// Extracted for readability
+final class CassandraSpanConsumer {
+
+  /**
+   * Internal flag that allows you read-your-writes consistency during tests.
+   *
+   * <p>This is internal as collection endpoints are usually in different threads or not in the same
+   * process as query ones. Special-casing this allows tests to pass without changing {@link
+   * SpanStore#accept(Iterator)}.
+   *
+   * <p>Why not just change {@link SpanStore#accept(Iterator)} now? <p>{@link
+   * SpanStore#accept(Iterator)} may indeed need to change, but when that occurs, we'd want to
+   * choose something that is widely supportable, and serving a specific use case. That api might
+   * not be a future, for example. Future is difficult, for example, properly supporting and testing
+   * cancel. Further, there are other async models such as callbacks that could be more supportable.
+   * Regardless, this work is best delayed until there's a worthwhile use-case vs up-fronting only
+   * due to tests, and prematurely choosing Future results.
+   */
+  static boolean BLOCK_ON_FUTURES;
+
+  private static final ThriftCodec THRIFT_CODEC = new ThriftCodec();
+
+  private final Repository repository;
+  private final int spanTtl;
+  private final int indexTtl;
+
+  CassandraSpanConsumer(Repository repository, int spanTtl, int indexTtl) {
+    this.repository = repository;
+    this.spanTtl = spanTtl;
+    this.indexTtl = indexTtl;
+  }
+
+  /**
+   * <p>Storing spans result in asynchronous operations to the backend repository. This
+   * implementation neither blocks on nor checks these futures, as the api doesn't require it.
+   */
+  void accept(Iterator<Span> spans) {
+    List<ListenableFuture<?>> futures = new LinkedList<>();
+    while (spans.hasNext()) {
+      Span span = ApplyTimestampAndDuration.apply(spans.next());
+      futures.add(repository.storeSpan(
+          span.traceId,
+          span.timestamp != null ? span.timestamp : 0L,
+          String.format("%d_%d_%d",
+              span.id,
+              span.annotations.hashCode(),
+              span.binaryAnnotations.hashCode()),
+          ByteBuffer.wrap(THRIFT_CODEC.writeSpan(span)),
+          spanTtl
+      ));
+
+      for (String serviceName : span.serviceNames()) {
+        // SpanStore.getServiceNames
+        futures.add(repository.storeServiceName(serviceName, indexTtl));
+        if (!span.name.isEmpty()) {
+          // SpanStore.getSpanNames
+          futures.add(repository.storeSpanName(serviceName, span.name, indexTtl));
+        }
+
+        if (span.timestamp != null) {
+          // QueryRequest.serviceName
+          futures.add(repository.storeTraceIdByServiceName(serviceName, span.timestamp,
+              span.traceId, indexTtl));
+
+          // QueryRequest.spanName
+          if (!span.name.isEmpty()) {
+            futures.add(repository.storeTraceIdBySpanName(
+                serviceName, span.name, span.timestamp, span.traceId, indexTtl));
+          }
+
+          // QueryRequest.min/maxDuration
+          if (span.duration != null) {
+            // Contract for Repository.storeTraceIdByDuration is to store the span twice, once with
+            // the span name and another with empty string.
+            futures.add(repository.storeTraceIdByDuration(
+                serviceName, span.name, span.timestamp, span.duration, span.traceId, indexTtl));
+            if (!span.name.isEmpty()) { // If span.name == "", this would be redundant
+              repository.storeTraceIdByDuration(
+                  serviceName, "", span.timestamp, span.duration, span.traceId, indexTtl);
+            }
+          }
+        }
+      }
+      // QueryRequest.annotations/binaryAnnotations
+      if (span.timestamp != null) {
+        for (ByteBuffer annotation : annotationKeys(span)) {
+          futures.add(repository.storeTraceIdByAnnotation(annotation, span.timestamp, span.traceId,
+              indexTtl));
+        }
+      }
+    }
+    if (BLOCK_ON_FUTURES) Futures.getUnchecked(Futures.allAsList(futures));
+  }
+}

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.twitter.zipkin.storage.cassandra.Repository;
+import zipkin.DependencyLink;
+import zipkin.QueryRequest;
+import zipkin.Span;
+import zipkin.SpanStore;
+import zipkin.internal.CorrectForClockSkew;
+import zipkin.internal.Dependencies;
+import zipkin.internal.MergeById;
+import zipkin.internal.Nullable;
+import zipkin.internal.Pair;
+import zipkin.internal.ThriftCodec;
+
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.getUnchecked;
+import static java.lang.String.format;
+import static zipkin.cassandra.CassandraUtil.annotationKeys;
+import static zipkin.internal.Util.midnightUTC;
+import static zipkin.internal.Util.sortedList;
+
+/**
+ * CQL3 implementation of a span store.
+ *
+ * <p>This uses zipkin-cassandra-core which packages "/cassandra-schema-cql3.txt"
+ */
+public final class CassandraSpanStore implements SpanStore, AutoCloseable {
+  private static final ThriftCodec THRIFT_CODEC = new ThriftCodec();
+  private static final Comparator<List<Span>> TRACE_DESCENDING = new Comparator<List<Span>>() {
+    @Override
+    public int compare(List<Span> left, List<Span> right) {
+      return right.get(0).compareTo(left.get(0));
+    }
+  };
+
+  private final String keyspace;
+  private final int indexTtl;
+  private final int maxTraceCols;
+  private final Cluster cluster;
+  final Repository repository;
+  private final CassandraSpanConsumer spanConsumer;
+
+  public CassandraSpanStore(CassandraConfig config) {
+    this.keyspace = config.keyspace;
+    this.indexTtl = config.indexTtl;
+    this.maxTraceCols = config.maxTraceCols;
+    this.cluster = config.toCluster();
+    this.repository = new Repository(config.keyspace, cluster, config.ensureSchema);
+    this.spanConsumer = new CassandraSpanConsumer(repository, config.spanTtl, config.indexTtl);
+  }
+
+  @Override
+  public void accept(Iterator<Span> spans) {
+    spanConsumer.accept(spans);
+  }
+
+  @Override
+  public List<List<Span>> getTraces(QueryRequest request) {
+    String spanName = request.spanName != null ? request.spanName : "";
+    final ListenableFuture<Map<Long, Long>> traceIdToTimestamp;
+    if (request.minDuration != null || request.maxDuration != null) {
+      traceIdToTimestamp = repository.getTraceIdsByDuration(request.serviceName, spanName,
+          request.minDuration, request.maxDuration != null ? request.maxDuration : Long.MAX_VALUE,
+          request.endTs * 1000, (request.endTs - request.lookback) * 1000, request.limit, indexTtl);
+    } else if (!spanName.isEmpty()) {
+      traceIdToTimestamp = repository.getTraceIdsBySpanName(request.serviceName, spanName,
+          request.endTs * 1000, request.lookback * 1000, request.limit);
+    } else {
+      traceIdToTimestamp = repository.getTraceIdsByServiceName(request.serviceName,
+          request.endTs * 1000, request.lookback * 1000, request.limit);
+    }
+
+    List<ByteBuffer> annotationKeys = annotationKeys(request);
+
+    // Simplest case is when there is no annotation query. Limit is valid since there's no AND query
+    // that could reduce the results returned to less than the limit.
+    if (annotationKeys.isEmpty()) {
+      return getTracesByIds(getUnchecked(traceIdToTimestamp).keySet());
+    }
+
+    // While a valid port of the scala cassandra span store (from zipkin 1.35), there is a fault.
+    // each annotation key is an intersection, which means we are likely to return less than limit.
+    List<ListenableFuture<Map<Long, Long>>> futureKeySetsToIntersect = new ArrayList<>();
+    futureKeySetsToIntersect.add(traceIdToTimestamp);
+    for (ByteBuffer annotationKey : annotationKeys) {
+      futureKeySetsToIntersect.add(repository.getTraceIdsByAnnotation(annotationKey,
+          request.endTs * 1000, request.lookback * 1000, request.limit));
+    }
+
+    // We achieve the AND goal, by intersecting each of the key sets.
+    List<Map<Long, Long>> keySetsToIntersect = getUnchecked(allAsList(futureKeySetsToIntersect));
+    Set<Long> traceIds = Sets.newLinkedHashSet(keySetsToIntersect.get(0).keySet());
+    for (int i = 1; i < keySetsToIntersect.size(); i++) {
+      traceIds.retainAll(keySetsToIntersect.get(i).keySet());
+    }
+
+    return getTracesByIds(traceIds);
+  }
+
+  @Override
+  public List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
+    // Synchronously get the encoded data, as there are no other requests to the backend needed.
+    Collection<List<ByteBuffer>> encodedTraces = getUnchecked(
+        repository.getSpansByTraceIds(traceIds.toArray(new Long[traceIds.size()]), maxTraceCols)
+    ).values();
+
+    List<List<Span>> result = new LinkedList<>(); // merging will imply a different size
+    for (List<ByteBuffer> encodedTrace : encodedTraces) {
+      List<Span> spans = new ArrayList<>(encodedTrace.size());
+      for (ByteBuffer encodedSpan : encodedTrace) {
+        spans.add(THRIFT_CODEC.readSpan(encodedSpan));
+      }
+      result.add(CorrectForClockSkew.apply(MergeById.apply(spans)));
+    }
+    Collections.sort(result, TRACE_DESCENDING);
+    return result;
+  }
+
+  @Override
+  public List<String> getServiceNames() {
+    return sortedList(getUnchecked(repository.getServiceNames()));
+  }
+
+  @Override
+  public List<String> getSpanNames(String service) {
+    if (service == null) return Collections.emptyList();
+    service = service.toLowerCase(); // service names are always lowercase!
+    return sortedList(getUnchecked(repository.getSpanNames(service)));
+  }
+
+  @Override
+  public List<DependencyLink> getDependencies(long endTs, @Nullable Long lookback) {
+    long endEpochDayMillis = midnightUTC(endTs);
+    long startEpochDayMillis = midnightUTC(endTs - (lookback != null ? lookback : endTs));
+
+    // Synchronously get the encoded data, as there are no other requests to the backend needed.
+    List<ByteBuffer> encodedDailyDependencies =
+        getUnchecked(repository.getDependencies(startEpochDayMillis, endEpochDayMillis));
+
+    // Combine the dependency links from startEpochDayMillis until endEpochDayMillis
+    Map<Pair<String>, Long> links = new LinkedHashMap<>(encodedDailyDependencies.size());
+
+    for (ByteBuffer encodedDayOfDependencies : encodedDailyDependencies) {
+      for (DependencyLink link : Dependencies.fromThrift(encodedDayOfDependencies).links) {
+        Pair<String> parentChild = Pair.create(link.parent, link.child);
+        long callCount = links.containsKey(parentChild) ? links.get(parentChild) : 0L;
+        callCount += link.callCount;
+        links.put(parentChild, callCount);
+      }
+    }
+
+    List<DependencyLink> result = new ArrayList<>(links.size());
+    for (Map.Entry<Pair<String>, Long> link : links.entrySet()) {
+      result.add(DependencyLink.create(link.getKey()._1, link.getKey()._2, link.getValue()));
+    }
+    return result;
+  }
+
+  /** Used for testing */
+  void clear() {
+    try (Session session = cluster.connect()) {
+      List<ListenableFuture<?>> futures = new LinkedList<>();
+      for (String cf : Arrays.asList(
+          "traces",
+          "dependencies",
+          "service_names",
+          "span_names",
+          "service_name_index",
+          "service_span_name_index",
+          "annotations_index",
+          "span_duration_index"
+      )) {
+        futures.add(session.executeAsync(format("TRUNCATE %s.%s", keyspace, cf)));
+      }
+      Futures.getUnchecked(Futures.allAsList(futures));
+    }
+  }
+
+  @Override
+  public void close() {
+    repository.close();
+    cluster.close();
+  }
+}

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraUtil.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraUtil.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.cassandra;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.twitter.zipkin.storage.cassandra.Repository;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.QueryRequest;
+import zipkin.Span;
+import zipkin.internal.Util;
+
+import static zipkin.internal.Util.UTF_8;
+
+final class CassandraUtil {
+  private static final CharsetEncoder UTF8_ENCODER = Util.UTF_8.newEncoder();
+
+  /**
+   * Returns keys that concatenate the serviceName associated with an annotation, a binary
+   * annotation key, or a binary annotation key with value.
+   *
+   * <p>Note: in the case of binary annotations, only string types are returned, as that's the only
+   * queryable type, per {@link QueryRequest#binaryAnnotations}.
+   *
+   * @see QueryRequest#annotations
+   * @see QueryRequest#binaryAnnotations
+   */
+  static List<ByteBuffer> annotationKeys(Span span) {
+    // Perform distinct with strings, since ByteBuffers don't do content-based hashCodes
+    Set<String> annotationKeys = new LinkedHashSet<>();
+    for (Annotation a : span.annotations) {
+      if (a.endpoint != null && !a.endpoint.serviceName.isEmpty()) {
+        annotationKeys.add(a.endpoint.serviceName + ":" + a.value);
+      }
+    }
+    for (BinaryAnnotation b : span.binaryAnnotations) {
+      if (b.type == BinaryAnnotation.Type.STRING
+          && b.endpoint != null
+          && !b.endpoint.serviceName.isEmpty()) {
+        annotationKeys.add(b.endpoint.serviceName + ":" + b.key);
+        annotationKeys.add(b.endpoint.serviceName + ":" + b.key + ":" + new String(b.value, UTF_8));
+      }
+    }
+    return toByteBuffers(annotationKeys);
+  }
+
+  static List<ByteBuffer> annotationKeys(QueryRequest request) {
+    // Perform distinct with strings, since ByteBuffers don't deal do content-based hashCodes
+    Set<String> annotationKeys = new LinkedHashSet<>();
+    for (String a : request.annotations) {
+      annotationKeys.add(request.serviceName + ":" + a);
+    }
+    for (Map.Entry<String, String> b : request.binaryAnnotations.entrySet()) {
+      annotationKeys.add(request.serviceName + ":" + b.getKey() + ":" + b.getValue());
+    }
+    return toByteBuffers(annotationKeys);
+  }
+
+  /** Eventhough the input is always a string, {@link Repository} requires byte buffer inputs. */
+  private static List<ByteBuffer> toByteBuffers(Collection<String> strings) {
+    if (strings.isEmpty()) return Collections.emptyList();
+    List<ByteBuffer> result = new ArrayList<>(strings.size());
+    for (String string : strings) {
+      try {
+        result.add(UTF8_ENCODER.encode(CharBuffer.wrap(string)));
+      } catch (CharacterCodingException ignored) {
+        // don't die if the encoding is unknown
+      }
+    }
+    return result;
+  }
+}

--- a/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraConfigTest.java
+++ b/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraConfigTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.datastax.driver.core.AuthProvider;
+import com.datastax.driver.core.Authenticator;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CassandraConfigTest {
+
+  @Test
+  public void contactPoints_defaultsToLocalhost() {
+    CassandraConfig config = CassandraConfig.builder().build();
+
+    assertThat(config.parseContactPoints())
+        .containsExactly(new InetSocketAddress("127.0.0.1", 9042));
+  }
+
+  @Test
+  public void contactPoints_defaultsToPort9042() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1")
+        .build();
+
+    assertThat(config.parseContactPoints())
+        .containsExactly(new InetSocketAddress("1.1.1.1", 9042));
+  }
+
+  @Test
+  public void contactPoints_defaultsToPort9042_multi() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1:9143,2.2.2.2")
+        .build();
+
+    assertThat(config.parseContactPoints()).containsExactly(
+        new InetSocketAddress("1.1.1.1", 9143),
+        new InetSocketAddress("2.2.2.2", 9042)
+    );
+  }
+
+  @Test
+  public void contactPoints_hostAndPort() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1:9142")
+        .build();
+
+    assertThat(config.parseContactPoints())
+        .containsExactly(new InetSocketAddress("1.1.1.1", 9142));
+  }
+
+  @Test
+  public void connectPort_singleContactPoint() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1:9142")
+        .build();
+
+    assertThat(config.toCluster().getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9142);
+  }
+
+  @Test
+  public void connectPort_whenContactPointsHaveSamePort() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1:9143,2.2.2.2:9143")
+        .build();
+
+    assertThat(config.toCluster().getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9143);
+  }
+
+  @Test
+  public void connectPort_whenContactPointsHaveMixedPorts_coercesToDefault() {
+    CassandraConfig config = CassandraConfig.builder()
+        .contactPoints("1.1.1.1:9143,2.2.2.2")
+        .build();
+
+    assertThat(config.toCluster().getConfiguration().getProtocolOptions().getPort())
+        .isEqualTo(9042);
+  }
+
+  @Test
+  public void usernamePassword_impliesNullDelimitedUtf8Bytes() {
+    CassandraConfig config = CassandraConfig.builder()
+        .username("bob")
+        .password("secret")
+        .build();
+
+    Authenticator authenticator =
+        config.toCluster().getConfiguration().getProtocolOptions().getAuthProvider()
+            .newAuthenticator(new InetSocketAddress("localhost", 8080));
+
+    byte[] SASLhandshake = {0, 'b', 'o', 'b', 0, 's', 'e', 'c', 'r', 'e', 't'};
+    assertThat(authenticator.initialResponse())
+        .isEqualTo(SASLhandshake);
+  }
+
+  @Test
+  public void authProvider_defaultsToNone() {
+    CassandraConfig config = CassandraConfig.builder().build();
+
+    assertThat(config.toCluster().getConfiguration().getProtocolOptions().getAuthProvider())
+        .isEqualTo(AuthProvider.NONE);
+  }
+
+  @Test
+  public void loadBalancing_defaultsToFirstHostDatacenter() {
+    CassandraConfig config = CassandraConfig.builder().build();
+
+    DCAwareRoundRobinPolicy policy = toDCAwareRoundRobinPolicy(config);
+
+    Host foo = mock(Host.class);
+    when(foo.getDatacenter()).thenReturn("foo");
+    Host bar = mock(Host.class);
+    when(bar.getDatacenter()).thenReturn("bar");
+    policy.init(mock(Cluster.class), asList(foo, bar));
+
+    assertThat(policy.distance(foo)).isEqualTo(HostDistance.LOCAL);
+    assertThat(policy.distance(bar)).isEqualTo(HostDistance.IGNORED);
+  }
+
+  @Test
+  public void loadBalancing_settingLocalDcIgnoresOtherDatacenters() {
+    CassandraConfig config = CassandraConfig.builder().localDc("bar").build();
+
+    DCAwareRoundRobinPolicy policy = toDCAwareRoundRobinPolicy(config);
+
+    Host foo = mock(Host.class);
+    when(foo.getDatacenter()).thenReturn("foo");
+    Host bar = mock(Host.class);
+    when(bar.getDatacenter()).thenReturn("bar");
+    policy.init(mock(Cluster.class), asList(foo, bar));
+
+    assertThat(policy.distance(foo)).isEqualTo(HostDistance.IGNORED);
+    assertThat(policy.distance(bar)).isEqualTo(HostDistance.LOCAL);
+  }
+
+  private static DCAwareRoundRobinPolicy toDCAwareRoundRobinPolicy(CassandraConfig config) {
+    return (DCAwareRoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) config.toCluster()
+        .getConfiguration()
+        .getPolicies()
+        .getLoadBalancingPolicy())
+        .getChildPolicy()).getChildPolicy();
+  }
+
+  @Test
+  public void maxConnections_defaultsTo8() {
+    CassandraConfig config = CassandraConfig.builder().build();
+
+    PoolingOptions poolingOptions = config.toCluster().getConfiguration().getPoolingOptions();
+
+    assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(8);
+  }
+
+  @Test
+  public void maxConnections_setsMaxConnectionsPerDatacenterLocalHost() {
+    CassandraConfig config = CassandraConfig.builder().maxConnections(16).build();
+
+    PoolingOptions poolingOptions = config.toCluster().getConfiguration().getPoolingOptions();
+
+    assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(16);
+  }
+}

--- a/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
+++ b/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.google.common.util.concurrent.Futures;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.twitter.zipkin.storage.cassandra.Repository;
+import zipkin.DependenciesTest;
+import zipkin.DependencyLink;
+import zipkin.InMemorySpanStore;
+import zipkin.Span;
+import zipkin.SpanStore;
+import zipkin.internal.Dependencies;
+
+import static zipkin.internal.Util.midnightUTC;
+
+public class CassandraDependenciesTest extends DependenciesTest<CassandraSpanStore> {
+
+  public CassandraDependenciesTest() {
+    this.store = CassandraTestGraph.INSTANCE.spanStore();
+  }
+
+  @Override
+  public void clear() {
+    store.clear();
+  }
+
+  /**
+   * The current implementation does not include dependency aggregation. It includes retrieval of
+   * pre-aggregated links.
+   *
+   * <p>This uses {@link InMemorySpanStore} to prepare links and {@link
+   * Repository#storeDependencies(long, ByteBuffer)} to store them.
+   *
+   * <p>Note: The zipkin-dependencies-spark doesn't use any of these classes: it reads and writes to
+   * the keyspace directly.
+   */
+  @Override
+  public void processDependencies(List<Span> spans) {
+    SpanStore mem = new InMemorySpanStore();
+    mem.accept(spans.iterator());
+    List<DependencyLink> links = mem.getDependencies(today + TimeUnit.DAYS.toMillis(1), null);
+
+    long midnight = midnightUTC(spans.get(0).timestamp / 1000);
+    Dependencies deps = Dependencies.create(midnight, midnight /* ignored */, links);
+    ByteBuffer thrift = deps.toThrift();
+    // Block on the future to get read-your-writes consistency during tests
+    Futures.getUnchecked(store.repository.storeDependencies(midnight, thrift));
+  }
+}

--- a/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraSpanStoreTest.java
+++ b/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraSpanStoreTest.java
@@ -11,31 +11,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.server;
+package zipkin.cassandra;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.SpanStoreTest;
 
-@ConfigurationProperties("zipkin")
-class ZipkinServerProperties {
-  private Store store = new Store();
+public class CassandraSpanStoreTest extends SpanStoreTest<CassandraSpanStore> {
 
-  public Store getStore() {
-    return store;
+  public CassandraSpanStoreTest() {
+    this.store = CassandraTestGraph.INSTANCE.spanStore();
   }
 
-  static class Store {
-    enum Type {
-      cassandra, mysql, mem
-    }
-
-    private Type type = Type.mem;
-
-    public Type getType() {
-      return type;
-    }
-
-    public void setType(Type type) {
-      this.type = type;
-    }
+  @Override
+  public void clear() {
+    store.clear();
   }
 }

--- a/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraTestGraph.java
+++ b/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraTestGraph.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.junit.AssumptionViolatedException;
+
+enum CassandraTestGraph {
+  INSTANCE;
+
+  private static final CassandraConfig CONFIG = new CassandraConfig.Builder()
+      .keyspace("test_zipkin_spanstore").build();
+
+  static {
+    // Avoid race-conditions in travis by forcing read-your-writes consistency.
+    CassandraSpanConsumer.BLOCK_ON_FUTURES = true;
+    // Ensure the repository's local cache of service names expire quickly
+    System.setProperty("zipkin.store.cassandra.internal.writtenNamesTtl", "1");
+  }
+
+  private AssumptionViolatedException ex;
+  private CassandraSpanStore spanStore;
+
+  /** A lot of tech debt here because the repository constructor performs I/O. */
+  synchronized CassandraSpanStore spanStore() {
+    if (ex != null) throw ex;
+    if (this.spanStore == null) {
+      try {
+        this.spanStore = new CassandraSpanStore(CONFIG);
+      } catch (NoHostAvailableException e) {
+        throw ex = new AssumptionViolatedException(e.getMessage());
+      }
+    }
+    return spanStore;
+  }
+}

--- a/zipkin-spanstores/pom.xml
+++ b/zipkin-spanstores/pom.xml
@@ -28,6 +28,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>cassandra</module>
     <module>jdbc</module>
   </modules>
 </project>


### PR DESCRIPTION
This is a port of `CassandraSpanStore` from zipkin-scala, except notably
not including the "slice query" infrastructure.

Note: While `CassandraSpanStore.accept` doesn't return a `Future`, it is
still asynchronous inside.

`zipkin-server` has been extended to optionally support Cassandra using
the same environment variables as zipkin-scala. For example, you can
start a process using cassandra as simply as setting the `STORAGE_TYPE`:

```bash
STORAGE_TYPE=cassandra ./mvnw -pl zipkin-server spring-boot:run
```

This uses the `Repository` class from `zipkin-cassandra-core`, which
internally uses DataStax Java Driver 2.1. It is likely that we'll
refactor out this dependency, for a couple reasons. One is that DataStax
Java Driver 3 is current. Another is that `Repository` was designed for
"slice query" infrastructure that doesn't exist in this project: there
are places where logic would be simpler to address in raw CQL.

This was tested using zipkin-scala's integration tests, local integration
tests, running the server with spring boot, and processing data with
`zipkin-dependencies-spark`.

Fixes #89 