### PR TITLE
Adds SpanConsumer and settles on List, not Iterator

### DIFF
--- a/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -13,11 +13,9 @@
  */
 package zipkin.interop;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twitter.util.Future;
 import com.twitter.zipkin.common.Span;
 import com.twitter.zipkin.conversions.thrift$;
-import com.twitter.zipkin.json.ZipkinJson$;
 import com.twitter.zipkin.storage.QueryRequest;
 import java.util.ArrayList;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -98,7 +96,7 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
 
   @Override
   public Future<BoxedUnit> apply(Seq<Span> input) {
-    spanStore.accept(ScalaSpanStoreAdapter.invert(input).iterator());
+    spanStore.accept(ScalaSpanStoreAdapter.invert(input));
     return Future.Unit();
   }
 

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -84,7 +84,7 @@ final class ZipkinDispatcher extends Dispatcher {
         String type = request.getHeader("Content-Type");
         Codec codec = type != null && type.contains("/x-thrift") ? Codec.THRIFT : JSON_CODEC;
         List<Span> spans = codec.readSpans(body);
-        store.accept(spans.iterator());
+        store.accept(spans);
         return new MockResponse().setResponseCode(202);
       }
     } else { // unsupported method

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
@@ -117,8 +117,8 @@ public final class ZipkinRule implements TestRule {
    * <p>For example, if you are testing what happens when instrumentation adds a child to a trace,
    * you'd add the parent here.
    */
-  public ZipkinRule storeSpans(Iterable<Span> spans) {
-    store.accept(spans.iterator());
+  public ZipkinRule storeSpans(List<Span> spans) {
+    store.accept(spans);
     return this;
   }
 

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -52,10 +51,8 @@ final class HttpSpanStore implements SpanStore {
   }
 
   @Override
-  public void accept(Iterator<Span> spans) {
-    List<Span> copy = new ArrayList<>();
-    while (spans.hasNext()) copy.add(spans.next());
-    byte[] spansInJson = JSON_CODEC.writeSpans(copy);
+  public void accept(List<Span> spans) {
+    byte[] spansInJson = JSON_CODEC.writeSpans(spans);
     call(new Request.Builder()
         .url(baseUrl.resolve("/api/v1/spans"))
         .post(RequestBody.create(MediaType.parse("application/json"), spansInJson)).build()

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -123,7 +123,7 @@ public class ZipkinQueryApiV1 {
       }
       return ResponseEntity.badRequest().body(e.getMessage() + "\n"); // newline for prettier curl
     }
-    spanWriter.write(spanStore, spans);
+    spanWriter.accept(spans);
     return ResponseEntity.accepted().build();
   }
 

--- a/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -62,7 +62,7 @@ public class SpanStoreSpanCollector implements SpanCollector, Flushable {
       }
     }
     if (!spans.isEmpty()) {
-      spanStore.accept(spans.iterator());
+      spanStore.accept(spans);
     }
   }
 

--- a/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
@@ -16,7 +16,6 @@ package zipkin.server.brave;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.LocalTracer;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import zipkin.DependencyLink;
 import zipkin.QueryRequest;
@@ -36,7 +35,7 @@ public final class TraceWritesSpanStore implements SpanStore {
   }
 
   @Override
-  public void accept(Iterator<Span> spans) {
+  public void accept(List<Span> spans) {
     delegate.accept(spans); // don't trace writes
   }
 

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
@@ -80,7 +80,7 @@ public final class CassandraSpanStore implements SpanStore, AutoCloseable {
   }
 
   @Override
-  public void accept(Iterator<Span> spans) {
+  public void accept(List<Span> spans) {
     spanConsumer.accept(spans);
   }
 

--- a/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
+++ b/zipkin-spanstores/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
@@ -51,7 +51,7 @@ public class CassandraDependenciesTest extends DependenciesTest<CassandraSpanSto
   @Override
   public void processDependencies(List<Span> spans) {
     SpanStore mem = new InMemorySpanStore();
-    mem.accept(spans.iterator());
+    mem.accept(spans);
     List<DependencyLink> links = mem.getDependencies(today + TimeUnit.DAYS.toMillis(1), null);
 
     long midnight = midnightUTC(spans.get(0).timestamp / 1000);

--- a/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCDependenciesTest.java
+++ b/zipkin-spanstores/jdbc/src/test/java/zipkin/jdbc/JDBCDependenciesTest.java
@@ -35,6 +35,6 @@ public class JDBCDependenciesTest extends DependenciesTest<JDBCSpanStore> {
 
   @Override
   protected void processDependencies(List<Span> spans) {
-    store.accept(spans.iterator());
+    store.accept(spans);
   }
 }

--- a/zipkin/src/main/java/zipkin/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/InMemorySpanStore.java
@@ -13,12 +13,10 @@
  */
 package zipkin;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -33,20 +31,19 @@ import zipkin.internal.MergeById;
 import zipkin.internal.Nullable;
 import zipkin.internal.Util;
 
+import static zipkin.internal.Util.UTF_8;
 import static zipkin.internal.Util.sortedList;
 
 public final class InMemorySpanStore implements SpanStore {
-  static final Charset UTF_8 = Charset.forName("UTF-8");
-
   private final Multimap<Long, Span> traceIdToSpans = new LinkedListMultimap<>();
   private final Multimap<String, Long> serviceToTraceIds = new LinkedHashSetMultimap<>();
   private final Multimap<String, String> serviceToSpanNames = new LinkedHashSetMultimap<>();
   private int acceptedSpanCount;
 
   @Override
-  public synchronized void accept(Iterator<Span> spans) {
-    while (spans.hasNext()) {
-      Span span = ApplyTimestampAndDuration.apply(spans.next());
+  public synchronized void accept(List<Span> spans) {
+    for (Span span : spans) {
+      span = ApplyTimestampAndDuration.apply(span);
       long traceId = span.traceId;
       String spanName = span.name;
       traceIdToSpans.put(span.traceId, span);

--- a/zipkin/src/main/java/zipkin/SamplingSpanStoreConsumer.java
+++ b/zipkin/src/main/java/zipkin/SamplingSpanStoreConsumer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/** Writes spans to storage, subject to sampling policy. */
+public final class SamplingSpanStoreConsumer implements SpanConsumer {
+
+  public static SpanConsumer create(Sampler sampler, SpanStore spanStore) {
+    return new SamplingSpanStoreConsumer(sampler, spanStore);
+  }
+
+  final Sampler sampler;
+  final SpanStore spanStore;
+
+  SamplingSpanStoreConsumer(Sampler sampler, SpanStore spanStore) {
+    this.sampler = checkNotNull(sampler, "sampler");
+    this.spanStore = checkNotNull(spanStore, "spanStore");
+  }
+
+  @Override
+  public void accept(List<Span> input) {
+    List<Span> sampled = new ArrayList<>(input.size());
+    for (Span s : input) {
+      if ((s.debug != null && s.debug) || sampler.isSampled(s.traceId)) sampled.add(s);
+    }
+    spanStore.accept(sampled);
+  }
+}

--- a/zipkin/src/main/java/zipkin/SpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/SpanConsumer.java
@@ -11,30 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.junit;
+package zipkin;
 
 import java.util.List;
-import org.junit.Rule;
-import zipkin.DependenciesTest;
-import zipkin.Span;
 
-/** Tests the http interface of {@link ZipkinRule}. */
-public class ZipkinRuleDependenciesTest extends DependenciesTest<HttpSpanStore> {
+/**
+ * Spans are created in instrumentation, transported out-of-band, and eventually persisted. A span
+ * consumer is a stage along that pipeline. A common consumption case in zipkin is to write spans to
+ * storage after applying sampling policy.
+ */
+// @FunctionalInterface
+public interface SpanConsumer {
 
-  @Rule
-  public ZipkinRule server = new ZipkinRule();
-
-  public ZipkinRuleDependenciesTest() {
-    store = new HttpSpanStore(server.httpUrl());
-  }
-
-  @Override
-  public void clear() {
-    // no need.. the test rule does this
-  }
-
-  @Override
-  protected void processDependencies(List<Span> spans) {
-    store.accept(spans);
-  }
+  /**
+   * Receives a list of spans {@link Codec#readSpans(byte[]) decoded} from a transport. Usually,
+   * this is an asynchronous {@link SpanStore#accept store} command.
+   *
+   * @param spans may be subject to a {@link Sampler#isSampled(long) sampling policy}.
+   */
+  void accept(List<Span> spans);
 }

--- a/zipkin/src/main/java/zipkin/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/SpanStore.java
@@ -14,17 +14,19 @@
 package zipkin;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import zipkin.internal.Nullable;
 
-public interface SpanStore {
+public interface SpanStore extends SpanConsumer {
 
   /**
-   * Sinks the given spans, ignoring duplicate annotations.
+   * Schedules a write of spans to storage. Sampling should occur prior to invoking this.
+   *
+   * <p>It is implementation-specific whether or not spans with the same id are merged.
    */
-  // Iterator to permit simple filtering without Java 8 or third-party types.
-  void accept(Iterator<Span> spans);
+  // Collection as there's no implementation that decodes lazily and knowing span count helps.
+  @Override
+  void accept(List<Span> spans);
 
   /**
    * Get the available trace information from the storage system. Spans in trace are sorted by the

--- a/zipkin/src/test/java/zipkin/InMemoryDependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/InMemoryDependenciesTest.java
@@ -28,6 +28,6 @@ public class InMemoryDependenciesTest extends DependenciesTest<InMemorySpanStore
 
   @Override
   protected void processDependencies(List<Span> spans) {
-    store.accept(spans.iterator());
+    store.accept(spans);
   }
 }


### PR DESCRIPTION
Before this change, we accepted Iterator of spans instead of a list,
mainly to accomodate the sampling use case. It turns out that this is
awkward, and it also interferes with being able to know the count of
the input. Finally, in most cases the call to accept spans comes from
a codec, and that codec has already decoded a List. This changes the
primary input to a List instead of an Iterator.

This also moves the code that stores spans received by a transport into
a type `SpanConsumer`. This helps reduce the coupling around facets such
as collection-tier sampling, and also makes it easier to write other
transports such as Kafka.