### PR TITLE
Adds Kafka Transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <module>benchmarks</module>
     <module>interop</module>
     <module>zipkin-spanstores</module>
+    <module>zipkin-transports</module>
     <module>zipkin-server</module>
   </modules>
 
@@ -41,7 +42,7 @@
 
     <moshi.version>1.1.0</moshi.version>
     <okio.version>1.6.0</okio.version>
-    <spring-boot.version>1.3.2.RELEASE</spring-boot.version>
+    <spring-boot.version>1.3.3.RELEASE</spring-boot.version>
     <zipkin-scala.version>1.35.0</zipkin-scala.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
@@ -142,6 +143,12 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>spanstore-jdbc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>transport-kafka</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -53,6 +53,20 @@ Example usage:
 $ STORAGE_TYPE=mysql MYSQL_USER=root ./mvnw -pl zipkin-server spring-boot:run
 ```
 
+### Kafka
+The following apply when `KAFKA_ZOOKEEPER` is set:
+
+    * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.
+    * `KAFKA_TOPIC`: Defaults to zipkin
+    * `KAFKA_GROUP_ID`: Consumer group this process is consuming on behalf of. Defaults to zipkin
+    * `KAFKA_STREAMS`: Count of consumer threads consuming the topic. defaults to 1.
+
+Example usage:
+
+```bash
+$ TRANSPORT_TYPE=kafka KAFKA_ZOOKEEPER=127.0.0.1:2181 ./mvnw -pl zipkin-server spring-boot:run
+```
+
 ## Running with Docker
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin-java`.
 See [docker-zipkin-java](https://github.com/openzipkin/docker-zipkin-java) for details.

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -58,21 +58,6 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
-    <!-- Trace api controller activity with Brave -->
-    <dependency>
-      <groupId>com.github.kristofa</groupId>
-      <artifactId>brave-spring-web-servlet-interceptor</artifactId>
-      <version>${brave.version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.kristofa</groupId>
-      <artifactId>brave-spancollector-scribe</artifactId>
-      <version>${brave.version}</version>
-      <optional>true</optional>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
@@ -105,6 +90,28 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Kafka transport -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>transport-kafka</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Trace api controller activity with Brave -->
+    <dependency>
+      <groupId>com.github.kristofa</groupId>
+      <artifactId>brave-spring-web-servlet-interceptor</artifactId>
+      <version>${brave.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.kristofa</groupId>
+      <artifactId>brave-spancollector-scribe</artifactId>
+      <version>${brave.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("kafka")
+class ZipkinKafkaProperties {
+  private String topic = "zipkin";
+  private String zookeeper;
+  private String groupId = "zipkin";
+  private int streams = 1;
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public String getZookeeper() {
+    return zookeeper;
+  }
+
+  public void setZookeeper(String zookeeper) {
+    this.zookeeper = "".equals(zookeeper) ? null : zookeeper;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public int getStreams() {
+    return streams;
+  }
+
+  public void setStreams(int streams) {
+    this.streams = streams;
+  }
+}

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -19,6 +19,15 @@ mysql:
   db: ${MYSQL_DB:zipkin}
   max-active: ${MYSQL_MAX_CONNECTIONS:10}
   use-ssl: ${MYSQL_USE_SSL:false}
+kafka:
+  # ZooKeeper host string, comma-separated host:port value.
+  zookeeper: ${KAFKA_ZOOKEEPER:}
+  # Name of topic to poll for spans
+  topic: ${KAFKA_TOPIC:zipkin}
+  # Consumer group this process is consuming on behalf of.
+  group-id: ${KAFKA_GROUP_ID:zipkin}
+  # Count of consumer threads consuming the topic
+  streams: ${KAFKA_STREAMS:1}
 zipkin:
   collector:
     # percentage to traces to retain

--- a/zipkin-transports/kafka/README.md
+++ b/zipkin-transports/kafka/README.md
@@ -1,0 +1,24 @@
+# transport-kafka
+This transport polls a Kafka 8.2.2+ topic for messages that contain
+TBinaryProtocol big-endian encoded lists of spans. These spans are
+pushed to a span consumer.
+
+`zipkin.kafka.KafkaConfig` includes defaults that will operate
+against a local Cassandra installation.
+
+
+## Encoding spans into Kafka messages
+`Codec.THRIFT.writeSpans(spans)` encodes spans in the following fashion:
+
+The message's binary data includes a list header followed by N spans serialized in TBinaryProtocol
+```
+write_byte(12) // type of the list elements: 12 == struct
+write_i32(count) // count of spans that will follow
+for (int i = 0; i < count; i++) {
+  writeTBinaryProtocol(spans(i))
+}
+```
+
+### Legacy encoding
+Older versions of zipkin accepted a single span per message, as opposed
+to a list per message. This practice is deprecated, but still supported.

--- a/zipkin-transports/kafka/pom.xml
+++ b/zipkin-transports/kafka/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>zipkin-transports</artifactId>
+    <version>0.7.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>transport-kafka</artifactId>
+  <name>Span Transport: Kafka</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- This is pinned to Kafka 0.8.x client as 0.9.x brokers work with them, but not visa-versa
+         http://docs.confluent.io/2.0.0/upgrade.html -->
+    <kafka.version>0.8.2.2</kafka.version>
+    <!-- pinned to 0.8.2.2 -->
+    <kafka-junit.version>1.7</kafka-junit.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.11</artifactId>
+      <version>${kafka.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.charithe</groupId>
+      <artifactId>kafka-junit</artifactId>
+      <version>${kafka-junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaConfig.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaConfig.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.kafka;
+
+import java.util.Properties;
+import kafka.consumer.ConsumerConfig;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/** Configuration including defaults needed to consume spans from a Kafka topic. */
+public final class KafkaConfig {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String topic = "zipkin";
+    private String zookeeper;
+    private String groupId = "zipkin";
+    private int streams = 1;
+
+    /** Topic zipkin spans will be consumed from. Defaults to "zipkin" */
+    public Builder topic(String topic) {
+      this.topic = topic;
+      return this;
+    }
+
+    /** The zookeeper connect string, ex. 127.0.0.1:2181. No default */
+    public Builder zookeeper(String zookeeper) {
+      this.zookeeper = zookeeper;
+      return this;
+    }
+
+    /** The consumer group this process is consuming on behalf of. Defaults to "zipkin" */
+    public Builder groupId(String groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
+    /** Count of threads/streams consuming the topic. Defaults to 1 */
+    public Builder streams(int streams) {
+      this.streams = streams;
+      return this;
+    }
+
+    public KafkaConfig build() {
+      return new KafkaConfig(this);
+    }
+  }
+
+  final String topic;
+  final String zookeeper;
+  final String groupId;
+  final int streams;
+
+  KafkaConfig(Builder builder) {
+    this.topic = checkNotNull(builder.topic, "topic");
+    this.zookeeper = checkNotNull(builder.zookeeper, "zookeeper");
+    this.groupId = checkNotNull(builder.groupId, "groupId");
+    this.streams = builder.streams;
+  }
+
+  ConsumerConfig forConsumer() {
+    Properties props = new Properties();
+    props.put("zookeeper.connect", zookeeper);
+    props.put("group.id", groupId);
+    // Same default as zipkin-scala, and keeps tests from hanging
+    props.put("auto.offset.reset", "smallest");
+    return new ConsumerConfig(props);
+  }
+}

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaStreamProcessor.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaStreamProcessor.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.kafka;
+
+import java.util.List;
+import kafka.consumer.ConsumerIterator;
+import kafka.consumer.KafkaStream;
+import zipkin.Span;
+import zipkin.SpanConsumer;
+
+final class KafkaStreamProcessor implements Runnable {
+
+  private final KafkaStream<String, List<Span>> stream;
+  private final SpanConsumer spanConsumer;
+
+  KafkaStreamProcessor(KafkaStream<String, List<Span>> stream, SpanConsumer spanConsumer) {
+    this.stream = stream;
+    this.spanConsumer = spanConsumer;
+  }
+
+  @Override
+  public void run() {
+    ConsumerIterator<String, List<Span>> messages = stream.iterator();
+    while (messages.hasNext()) {
+      List<Span> spans = messages.next().message();
+      if (spans.isEmpty()) continue;
+      spanConsumer.accept(spans);
+    }
+  }
+}

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaTransport.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaTransport.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.kafka;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.serializer.StringDecoder;
+import zipkin.SpanConsumer;
+
+import static kafka.consumer.Consumer.createJavaConsumerConnector;
+
+/**
+ * This transport polls a Kafka topic for messages that contain TBinaryProtocol big-endian encoded
+ * lists of spans. These spans are pushed to a {@link SpanConsumer#accept(List) span consumer}.
+ */
+public final class KafkaTransport implements AutoCloseable {
+
+  final ExecutorService pool;
+
+  public KafkaTransport(KafkaConfig config, SpanConsumer spanConsumer) {
+    this.pool = config.streams == 1
+        ? Executors.newSingleThreadExecutor()
+        : Executors.newFixedThreadPool(config.streams);
+    ConsumerConnector connector = createJavaConsumerConnector(config.forConsumer());
+
+    Map<String, Integer> topicCountMap = new LinkedHashMap<>(1);
+    topicCountMap.put(config.topic, config.streams);
+
+    connector.createMessageStreams(topicCountMap, new StringDecoder(null), new SpansDecoder())
+        .get(config.topic).forEach(stream ->
+        pool.execute(new KafkaStreamProcessor(stream, spanConsumer))
+    );
+  }
+
+  @Override
+  public void close() {
+    pool.shutdown();
+  }
+}

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.kafka;
+
+import java.util.Collections;
+import java.util.List;
+import kafka.serializer.Decoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.Codec;
+import zipkin.Span;
+
+/**
+ * Conditionally decodes depending on whether the input bytes are encoded as a single span or a
+ * list. Malformed input is ignored.
+ */
+final class SpansDecoder implements Decoder<List<Span>> {
+
+  @Override
+  public List<Span> fromBytes(byte[] bytes) {
+    try {
+      // Given the thrift encoding is TBinaryProtocol..
+      // .. When serializing a Span (Struct), the first byte will be the type of a field
+      // .. When serializing a List[ThriftSpan], the first byte is the member type, TType.STRUCT
+      // Span has no STRUCT fields: we assume that if the first byte is TType.STRUCT is a list.
+      if (bytes[0] == 12 /* TType.STRUCT */) {
+        return Codec.THRIFT.readSpans(bytes);
+      } else {
+        return Collections.singletonList(Codec.THRIFT.readSpan(bytes));
+      }
+    } catch (IllegalArgumentException ignored) {
+      // binary decoding messages aren't useful enough to clutter logs with.
+      return Collections.emptyList();
+    }
+  }
+}

--- a/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaTransportTest.java
+++ b/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaTransportTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.kafka;
+
+import com.github.charithe.kafka.KafkaJunitRule;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import org.junit.ClassRule;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Codec;
+import zipkin.Endpoint;
+import zipkin.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.SERVER_RECV;
+
+public class KafkaTransportTest {
+  @ClassRule public static KafkaJunitRule kafka = new KafkaJunitRule();
+
+  Endpoint endpoint = Endpoint.create("web", 127 << 24 | 1, 80);
+  Annotation ann = Annotation.create(System.currentTimeMillis() * 1000, SERVER_RECV, endpoint);
+  Span span = new Span.Builder().id(1L).traceId(1L).timestamp(ann.timestamp).name("get")
+      .addAnnotation(ann).build();
+
+  /** Ensures legacy encoding works: a single TBinaryProtocol encoded span */
+  @Test
+  public void messageWithSingleSpan() throws Exception {
+    KafkaConfig config = KafkaConfig.builder()
+        .zookeeper(kafka.zookeeperConnectionString())
+        .topic("single_span").build();
+
+    CompletableFuture<List<Span>> promise = new CompletableFuture<>();
+
+    Producer<String, byte[]> producer = new Producer<>(kafka.producerConfigWithDefaultEncoder());
+    producer.send(new KeyedMessage<>(config.topic, Codec.THRIFT.writeSpan(span)));
+    producer.close();
+
+    try (KafkaTransport processor = new KafkaTransport(config, promise::complete)) {
+      assertThat(promise.get()).containsOnly(span);
+    }
+  }
+
+  /** Ensures list encoding works: a TBinaryProtocol encoded list of spans */
+  @Test
+  public void messageWithMultipleSpans() throws Exception {
+    KafkaConfig config = KafkaConfig.builder()
+        .zookeeper(kafka.zookeeperConnectionString())
+        .topic("multiple_spans").build();
+
+    CompletableFuture<List<Span>> promise = new CompletableFuture<>();
+
+    Producer<String, byte[]> producer = new Producer<>(kafka.producerConfigWithDefaultEncoder());
+    producer.send(new KeyedMessage<>(config.topic, Codec.THRIFT.writeSpans(asList(span, span))));
+    producer.close();
+
+    try (KafkaTransport processor = new KafkaTransport(config, promise::complete)) {
+      assertThat(promise.get()).containsExactly(span, span);
+    }
+  }
+
+  /** Ensures malformed spans don't hang the processor */
+  @Test
+  public void skipsMalformedData() throws Exception {
+    KafkaConfig config = KafkaConfig.builder()
+        .zookeeper(kafka.zookeeperConnectionString())
+        .topic("malformed").build();
+
+    LinkedBlockingQueue<List<Span>> recvdSpans = new LinkedBlockingQueue<>();
+
+    Producer<String, byte[]> producer = new Producer<>(kafka.producerConfigWithDefaultEncoder());
+    producer.send(new KeyedMessage<>(config.topic, Codec.THRIFT.writeSpans(asList(span))));
+    producer.send(new KeyedMessage<>(config.topic, "malformed".getBytes()));
+    producer.send(new KeyedMessage<>(config.topic, Codec.THRIFT.writeSpans(asList(span))));
+    producer.close();
+
+    try (KafkaTransport processor = new KafkaTransport(config, recvdSpans::add)) {
+      assertThat(recvdSpans.take()).containsExactly(span);
+      // the only way we could read this, is if the malformed span was skipped.
+      assertThat(recvdSpans.take()).containsExactly(span);
+    }
+  }
+}

--- a/zipkin-transports/kafka/src/test/resources/log4j.properties
+++ b/zipkin-transports/kafka/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+# By default, everything goes to console and file
+log4j.rootLogger=WARN, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+log4j.appender.A1.ImmediateFlush=true
+
+log4j.logger.kafka.utils=WARN, A1
+log4j.logger.kafka.consumer=WARN, A1
+log4j.logger.kafka.producer=WARN, A1

--- a/zipkin-transports/pom.xml
+++ b/zipkin-transports/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.7.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-transports</artifactId>
+  <name>Zipkin Span Transports</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>kafka</module>
+  </modules>
+</project>


### PR DESCRIPTION
This adds a Kafka transport, which receives messages in the same way as
zipkin-scala, using the same environment variables.

Closes #70