### PR TITLE
Reverts default Cassandra host policy to RoundRobin

### DIFF
--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
@@ -164,7 +165,7 @@ public final class CassandraConfig {
     builder.withLoadBalancingPolicy(new TokenAwarePolicy(new LatencyAwarePolicy.Builder(
         localDc != null
             ? DCAwareRoundRobinPolicy.builder().withLocalDc(localDc).build()
-            : DCAwareRoundRobinPolicy.builder().build()
+            : new RoundRobinPolicy() // This can select remote, but LatencyAwarePolicy will prefer local
     ).build()));
     builder.withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(
         HostDistance.LOCAL, maxConnections


### PR DESCRIPTION
When changing loadbalancer policy, we didn't consider a scenario brought
up by @michaelsembwever:

DCAwareRoundRobinPolicy will by default prefer the first contact node's
datacenter. If that node happens to be in a remote datacenter, latency
will be high, and the `LatencyAwarePolicy` cannot correct it (since
local nodes will be filtered out.

The previous logic is better because eventhough `RoundRobinPolicy` can
select a remote datacenter, it also selects local ones: the
`LatencyAwarePolicy` will eventually correct to choose only the local
ones.

See https://github.com/openzipkin/zipkin-java/pull/92/files#r55933918