### PR TITLE
Changes SpanStore.getTracesByIds to getTrace

### DIFF
--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -14,7 +14,6 @@
 package zipkin.junit;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.Dispatcher;
@@ -63,8 +62,8 @@ final class ZipkinDispatcher extends Dispatcher {
       } else if (url.encodedPath().startsWith("/api/v1/trace/")) {
         String traceId = url.encodedPath().replace("/api/v1/trace/", "");
         long id = new Buffer().writeUtf8(traceId).readHexadecimalUnsignedLong();
-        List<List<Span>> traces = store.getTracesByIds(Collections.singletonList(id));
-        if (!traces.isEmpty()) return jsonResponse(JSON_CODEC.writeSpans(traces.get(0)));
+        List<Span> trace = store.getTrace(id);
+        if (trace != null) return jsonResponse(JSON_CODEC.writeSpans(trace));
       }
     } else if (request.getMethod().equals("POST")) {
       if (url.encodedPath().equals("/api/v1/spans")) {

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinRule.java
@@ -14,6 +14,7 @@
 package zipkin.junit;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -140,7 +141,12 @@ public final class ZipkinRule implements TestRule {
 
   /** Retrieves all traces this zipkin server has received. */
   public List<List<Span>> getTraces() {
-    return store.getTracesByIds(store.traceIds());
+    List<Long> traceIds = store.traceIds();
+    List<List<Span>> result = new ArrayList<>(traceIds.size());
+    for (long traceId : traceIds) {
+      result.add(store.getTrace(traceId));
+    }
+    return result;
   }
 
   /**

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
@@ -14,10 +14,6 @@
 package zipkin.junit;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -74,26 +70,15 @@ final class HttpSpanStore implements SpanStore {
   }
 
   @Override
-  public List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
-    List<List<Span>> result = new ArrayList<>(traceIds.size());
-    for (Long id : traceIds) {
-      Response response = call(new Request.Builder()
-          .url(baseUrl.resolve(String.format("/api/v1/trace/%016x", id)))
-          .build());
-      if (response.code() != 404) {
-        result.add(JSON_CODEC.readSpans(responseBytes(response)));
-      }
+  public List<Span> getTrace(long traceId) {
+    Response response = call(new Request.Builder()
+        .url(baseUrl.resolve(String.format("/api/v1/trace/%016x", traceId)))
+        .build());
+    if (response.code() == 404) {
+      return null;
     }
-    Collections.sort(result, TRACE_DESCENDING);
-    return result;
+    return JSON_CODEC.readSpans(responseBytes(response));
   }
-
-  static final Comparator<List<Span>> TRACE_DESCENDING = new Comparator<List<Span>>() {
-    @Override
-    public int compare(List<Span> left, List<Span> right) {
-      return right.get(0).compareTo(left.get(0));
-    }
-  };
 
   @Override
   public List<String> getServiceNames() {

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -14,7 +14,6 @@
 package zipkin.server;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -152,12 +151,12 @@ public class ZipkinQueryApiV1 {
   @RequestMapping(value = "/trace/{traceId}", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
   public byte[] getTrace(@PathVariable String traceId) {
     long id = lowerHexToUnsignedLong(traceId);
-    List<List<Span>> traces = spanStore.getTracesByIds(Collections.singletonList(id));
+    List<Span> trace = spanStore.getTrace(id);
 
-    if (traces.isEmpty()) {
+    if (trace == null) {
       throw new TraceNotFoundException(traceId, id);
     }
-    return jsonCodec.writeSpans(traces.get(0));
+    return jsonCodec.writeSpans(trace);
   }
 
   @ExceptionHandler(TraceNotFoundException.class)

--- a/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
@@ -15,7 +15,6 @@ package zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.LocalTracer;
-import java.util.Collection;
 import java.util.List;
 import zipkin.DependencyLink;
 import zipkin.QueryRequest;
@@ -52,10 +51,10 @@ public final class TraceWritesSpanStore implements SpanStore {
   }
 
   @Override
-  public List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
-    tracer.startNewSpan(component, "get-traces-by-ids");
+  public List<Span> getTrace(long traceId) {
+    tracer.startNewSpan(component, "get-trace");
     try {
-      return delegate.getTracesByIds(traceIds);
+      return delegate.getTrace(traceId);
     } finally {
       tracer.finishSpan();
     }

--- a/zipkin-server/src/test/java/zipkin/server/brave/SpanStoreSpanCollectorTest.java
+++ b/zipkin-server/src/test/java/zipkin/server/brave/SpanStoreSpanCollectorTest.java
@@ -21,8 +21,7 @@ import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.InMemorySpanStore;
 
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpanStoreSpanCollectorTest {
 
@@ -51,7 +50,7 @@ public class SpanStoreSpanCollectorTest {
       collector.collect(builder.id(1234L + i).build());
     }
     collector.flush();
-    List<List<Span>> result = spanStore.getTracesByIds(singletonList(1234L));
-    assertThat(result.get(0)).hasSize(500);
+    List<Span> result = spanStore.getTrace(1234L);
+    assertThat(result).hasSize(500);
   }
 }

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -127,8 +126,7 @@ public final class CassandraSpanStore implements SpanStore, AutoCloseable {
     return getTracesByIds(traceIds);
   }
 
-  @Override
-  public List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
+  List<List<Span>> getTracesByIds(Collection<Long> traceIds) {
     // Synchronously get the encoded data, as there are no other requests to the backend needed.
     Collection<List<ByteBuffer>> encodedTraces = getUnchecked(
         repository.getSpansByTraceIds(traceIds.toArray(new Long[traceIds.size()]), maxTraceCols)
@@ -144,6 +142,12 @@ public final class CassandraSpanStore implements SpanStore, AutoCloseable {
     }
     Collections.sort(result, TRACE_DESCENDING);
     return result;
+  }
+
+  @Override
+  public List<Span> getTrace(long traceId) {
+    List<List<Span>> result = getTracesByIds(Collections.singleton(traceId));
+    return result.isEmpty() ? null : result.get(0);
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/SpanStore.java
@@ -13,7 +13,6 @@
  */
 package zipkin;
 
-import java.util.Collection;
 import java.util.List;
 import zipkin.internal.Nullable;
 
@@ -41,10 +40,10 @@ public interface SpanStore extends SpanConsumer {
    * Get the available trace information from the storage system. Spans in trace are sorted by the
    * first annotation timestamp in that span. First event should be first in the spans list.
    *
-   * <p/> Results are sorted in order of the first span's timestamp, and contain less elements than
-   * trace IDs when corresponding traces aren't available.
+   * @return a list of spans with the same {@link Span#traceId}, or null if not present.
    */
-  List<List<Span>> getTracesByIds(Collection<Long> traceIds);
+  @Nullable
+  List<Span> getTrace(long id);
 
   /**
    * Get all the {@link Endpoint#serviceName service names}.


### PR DESCRIPTION
In zipkin-scala, `SpanStore.getTracesByIds` served its "slice query"
implementation. Basically, the old infrastructure performed queries in
two steps: first, fetch ids. then, get traces by ID.

From an HTTP Api point of view, it is single-id `GET /api/v1/trace/id`.
Moreover, how or if to fan-out is an implemantation detail that varies
per storage layer.

This rips out `SpanStore.getTracesByIds` for `getTrace`, as it
simplifies the api, and the [raw query](https://github.com/openzipkin/zipkin/pull/1027) easier to implement.