### PR TITLE
Excludes eagerly bound logging dependencies from Kafka

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -67,6 +67,19 @@ Example usage:
 $ TRANSPORT_TYPE=kafka KAFKA_ZOOKEEPER=127.0.0.1:2181 ./mvnw -pl zipkin-server spring-boot:run
 ```
 
+Example targeting Kafka running in Docker:
+
+```bash
+$ export KAFKA_ZOOKEEPER=$(docker-machine ip `docker-machine active`)
+# Run Kafka in the background
+$ docker run -d -p 2181:2181 -p 9092:9092 \
+    --env ADVERTISED_HOST=$KAFKA_ZOOKEEPER \
+    --env AUTO_CREATE_TOPICS=true \
+    spotify/kafka
+# Start the zipkin server, which reads $KAFKA_ZOOKEEPER
+$ TRANSPORT_TYPE=kafka ./mvnw -pl zipkin-server spring-boot:run
+```
+
 ## Running with Docker
 Released versions of zipkin-server are published to Docker Hub as `openzipkin/zipkin-java`.
 See [docker-zipkin-java](https://github.com/openzipkin/docker-zipkin-java) for details.

--- a/zipkin-transports/kafka/README.md
+++ b/zipkin-transports/kafka/README.md
@@ -3,8 +3,8 @@ This transport polls a Kafka 8.2.2+ topic for messages that contain
 TBinaryProtocol big-endian encoded lists of spans. These spans are
 pushed to a span consumer.
 
-`zipkin.kafka.KafkaConfig` includes defaults that will operate
-against a local Cassandra installation.
+`zipkin.kafka.KafkaConfig` includes defaults that will operate against a
+Kafka topic advertised in Zookeeper.
 
 
 ## Encoding spans into Kafka messages

--- a/zipkin-transports/kafka/pom.xml
+++ b/zipkin-transports/kafka/pom.xml
@@ -45,6 +45,18 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
       <version>${kafka.version}</version>
+      <!-- excludes eagerly bound logger dependencies,
+           so that they don't leak into zipkin-server -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This excludes a couple dependencies that leak through consumers such as
zipkin-server. It also adds instructions for testing Kafka using Docker.

Fixes #99