### PR TITLE
Supports viewing raw traces via GET /api/v1/trace/:id?raw

### DIFF
--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -62,7 +62,8 @@ final class ZipkinDispatcher extends Dispatcher {
       } else if (url.encodedPath().startsWith("/api/v1/trace/")) {
         String traceId = url.encodedPath().replace("/api/v1/trace/", "");
         long id = new Buffer().writeUtf8(traceId).readHexadecimalUnsignedLong();
-        List<Span> trace = store.getTrace(id);
+        List<Span> trace = url.queryParameterNames().contains("raw")
+            ? store.getRawTrace(id) : store.getTrace(id);
         if (trace != null) return jsonResponse(JSON_CODEC.writeSpans(trace));
       }
     } else if (request.getMethod().equals("POST")) {

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpSpanStore.java
@@ -71,8 +71,17 @@ final class HttpSpanStore implements SpanStore {
 
   @Override
   public List<Span> getTrace(long traceId) {
+    return getTrace(traceId, false);
+  }
+
+  @Override
+  public List<Span> getRawTrace(long traceId) {
+    return getTrace(traceId, true);
+  }
+
+  private List<Span> getTrace(long id, boolean raw) {
     Response response = call(new Request.Builder()
-        .url(baseUrl.resolve(String.format("/api/v1/trace/%016x", traceId)))
+        .url(baseUrl.resolve(String.format("/api/v1/trace/%016x%s", id, raw ? "?raw" : "")))
         .build());
     if (response.code() == 404) {
       return null;

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 import zipkin.Codec;
 import zipkin.QueryRequest;
 import zipkin.Span;
@@ -149,9 +150,10 @@ public class ZipkinQueryApiV1 {
   }
 
   @RequestMapping(value = "/trace/{traceId}", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
-  public byte[] getTrace(@PathVariable String traceId) {
+  public byte[] getTrace(@PathVariable String traceId, WebRequest request) {
     long id = lowerHexToUnsignedLong(traceId);
-    List<Span> trace = spanStore.getTrace(id);
+    String[] raw = request.getParameterValues("raw"); // RequestParam doesn't work for param w/o value
+    List<Span> trace = raw != null ? spanStore.getRawTrace(id) : spanStore.getTrace(id);
 
     if (trace == null) {
       throw new TraceNotFoundException(traceId, id);

--- a/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TraceWritesSpanStore.java
@@ -61,6 +61,16 @@ public final class TraceWritesSpanStore implements SpanStore {
   }
 
   @Override
+  public List<Span> getRawTrace(long traceId) {
+    tracer.startNewSpan(component, "get-spans-by-trace-id");
+    try {
+      return delegate.getRawTrace(traceId);
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Override
   public List<String> getServiceNames() {
     tracer.startNewSpan(component, "get-service-names");
     try {

--- a/zipkin/src/main/java/zipkin/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/InMemorySpanStore.java
@@ -110,9 +110,15 @@ public final class InMemorySpanStore implements SpanStore {
 
   @Override
   public synchronized List<Span> getTrace(long traceId) {
-    Collection<Span> spans = traceIdToSpans.get(traceId);
+    List<Span> spans = getRawTrace(traceId);
+    return spans == null ? null : CorrectForClockSkew.apply(MergeById.apply(spans));
+  }
+
+  @Override
+  public synchronized List<Span> getRawTrace(long traceId) {
+    List<Span> spans = (List<Span>) traceIdToSpans.get(traceId);
     if (spans == null || spans.isEmpty()) return null;
-    return CorrectForClockSkew.apply(MergeById.apply(spans));
+    return spans;
   }
 
   @Override

--- a/zipkin/src/main/java/zipkin/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/SpanStore.java
@@ -46,6 +46,19 @@ public interface SpanStore extends SpanConsumer {
   List<Span> getTrace(long id);
 
   /**
+   * Retrieves spans that share a trace id, as returned from backend data store queries, with no
+   * ordering expectation.
+   *
+   * <p>This is different, but related to {@link #getTrace}. {@link #getTrace} cleans data by
+   * merging spans, adding timestamps and performing clock skew adjustment. This feature is for
+   * debugging zipkin logic or zipkin instrumentation.
+   *
+   * @return a list of spans with the same {@link Span#traceId}, or null if not present.
+   */
+  @Nullable
+  List<Span> getRawTrace(long traceId);
+
+  /**
    * Get all the {@link Endpoint#serviceName service names}.
    *
    * <p/> Results are sorted lexicographically


### PR DESCRIPTION
When troubleshooting instrumentation, we sometimes need to hop to the
database to see what the collector stored (which is closer to what the
instrumentation sent).

In some cases, we are hunting down "clock skew" problems, and sometimes
that's a red herring. Some times we are looking to see if applications
are sending the same span multiple times. The reason we have to go to
the database is we can't quite tell if query-time adjustment logic is
helping or hurting.

This introduces a new query flag "raw" to the get trace endpoint. When
specified, no query time adjustments are made after data is returned
from the backend.

See https://github.com/openzipkin/zipkin/pull/1027