### PR TITLE
Allows transport-kafka to consume JSON encoded spans

### DIFF
--- a/zipkin-transports/kafka/README.md
+++ b/zipkin-transports/kafka/README.md
@@ -1,16 +1,31 @@
 # transport-kafka
 This transport polls a Kafka 8.2.2+ topic for messages that contain
-TBinaryProtocol big-endian encoded lists of spans. These spans are
-pushed to a span consumer.
+a list of spans in json or TBinaryProtocol big-endian encoding. These
+spans are pushed to a span consumer.
 
 `zipkin.kafka.KafkaConfig` includes defaults that will operate against a
 Kafka topic advertised in Zookeeper.
 
+### Encoding spans into Kafka messages
+The message's binary data includes a list of spans. Supported encodings
+are the same as the http [POST /spans](http://zipkin.io/zipkin-api/#/paths/%252Fspans) body.
 
-## Encoding spans into Kafka messages
-`Codec.THRIFT.writeSpans(spans)` encodes spans in the following fashion:
+#### Json
+The message's binary data is a list of spans in json. The first character must be '[' (decimal 91).
 
+`Codec.JSON.writeSpans(spans)` performs the correct json encoding.
+
+Here's an example, sending a list of a single span to the zipkin topic:
+
+```bash
+$ kafka-console-producer.sh --broker-list $ADVERTISED_HOST:9092 --topic zipkin
+[{"traceId":"1","name":"bang","id":"2","timestamp":1234,"binaryAnnotations":[{"key":"lc","value":"bamm-bamm","endpoint":{"serviceName":"flintstones","ipv4":"127.0.0.1"}}]}]
+```
+
+#### Thrift
 The message's binary data includes a list header followed by N spans serialized in TBinaryProtocol
+
+`Codec.THRIFT.writeSpans(spans)` encodes spans in the following fashion:
 ```
 write_byte(12) // type of the list elements: 12 == struct
 write_i32(count) // count of spans that will follow


### PR DESCRIPTION
By allowing JSON encoded span lists as Kafka message values, we enable
users to send the same payload as they can over the http transport. It
also allows a very easy debug story, such as sending test spans via CLI.

This implementation peeks at the first byte in the Kafka message, and
attempts to decode json, if it is a '[', or decimal 91. When using
TBinaryProtocol (thrift) encoding, we know that the first byte will be
the Type, which is decimal <=16, so there's no risk of clash.

See https://github.com/openzipkin/zipkin/pull/1052