### PR TITLE
Exposes CASSANDRA_SPAN_TTL and CASSANDRA_INDEX_TTL variables

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -30,6 +30,8 @@ The following apply when `STORAGE_TYPE` is set to `cassandra`:
     * `CASSANDRA_MAX_CONNECTIONS`: Max pooled connections per datacenter-local host. Defaults to 8
     * `CASSANDRA_ENSURE_SCHEMA`: Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt. Defaults to true
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails. No default
+    * `CASSANDRA_SPAN_TTL`: Time-to-live in seconds for span data. Defaults to 604800 (7 days)
+    * `CASSANDRA_INDEX_TTL`: Time-to-live in seconds for index data. Defaults to 259200 (3 days)
 
 Example usage:
 

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
@@ -13,6 +13,7 @@
  */
 package zipkin.server;
 
+import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("cassandra")
@@ -24,6 +25,8 @@ class ZipkinCassandraProperties {
   private boolean ensureSchema = true;
   private String username;
   private String password;
+  private int spanTtl = (int) TimeUnit.DAYS.toSeconds(7);
+  private int indexTtl = (int) TimeUnit.DAYS.toSeconds(3);
 
   public String getKeyspace() {
     return keyspace;
@@ -79,5 +82,21 @@ class ZipkinCassandraProperties {
 
   public void setPassword(String password) {
     this.password = "".equals(password) ? null : password;
+  }
+
+  public int getSpanTtl() {
+    return spanTtl;
+  }
+
+  public void setSpanTtl(int spanTtl) {
+    this.spanTtl = spanTtl;
+  }
+
+  public int getIndexTtl() {
+    return indexTtl;
+  }
+
+  public void setIndexTtl(int indexTtl) {
+    this.indexTtl = indexTtl;
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
@@ -89,7 +89,9 @@ public class ZipkinServerConfiguration {
           .maxConnections(cassandra.getMaxConnections())
           .ensureSchema(cassandra.isEnsureSchema())
           .username(cassandra.getUsername())
-          .password(cassandra.getPassword()).build();
+          .password(cassandra.getPassword())
+          .spanTtl(cassandra.getSpanTtl())
+          .indexTtl(cassandra.getIndexTtl()).build();
       return new CassandraSpanStore(config);
     } else {
       return new InMemorySpanStore();

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -11,6 +11,10 @@ cassandra:
   max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
   # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
   ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
+  # 7 days in seconds
+  span-ttl: ${CASSANDRA_SPAN_TTL:604800}
+  # 3 days in seconds
+  index-ttl: ${CASSANDRA_INDEX_TTL:259200}
 mysql:
   host: ${MYSQL_HOST:localhost}
   port: ${MYSQL_TCP_PORT:3306}
@@ -53,7 +57,7 @@ spring:
     schema: classpath:/mysql.sql
 # Switch this on to create the schema on startup:
     initialize: false
-# Example of how to log codec failures
+# Example of how to log cassandra calls
 # logging:
 #     level:
-#         zipkin.server.ZipkinQueryApiV1: 'FINE'
+#         org.twitter.zipkin.storage.cassandra.Repository: 'DEBUG'

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraConfig.java
@@ -111,15 +111,15 @@ public final class CassandraConfig {
       return this;
     }
 
-    /** Time-to-live in seconds for index data. Defaults to 3 days */
-    public Builder indexTtl(int indexTtl) {
-      this.indexTtl = indexTtl;
+    /** Time-to-live in seconds for span data. Defaults to 604800 (7 days) */
+    public Builder spanTtl(int spanTtl) {
+      this.spanTtl = spanTtl;
       return this;
     }
 
-    /** Time-to-live in seconds for span data. Defaults to 7 days */
-    public Builder spanTtl(int spanTtl) {
-      this.spanTtl = spanTtl;
+    /** Time-to-live in seconds for index data. Defaults to 259200 (3 days) */
+    public Builder indexTtl(int indexTtl) {
+      this.indexTtl = indexTtl;
       return this;
     }
 


### PR DESCRIPTION
Span and Index Time-to-lives were already configurable, but not via properties. This fixes that.

   * `CASSANDRA_SPAN_TTL`: Time-to-live in seconds for span data. Defaults to 604800 (7 days)
   * `CASSANDRA_INDEX_TTL`: Time-to-live in seconds for index data. Defaults to 259200 (3 days)

By adding the above, we remain compatible with the scala query and collector services.

See https://github.com/openzipkin/zipkin/pull/1055