### PR TITLE
Prunes compile dependencies of zipkin-server to zipkin-core and spring

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -79,12 +79,14 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>spanstore-cassandra</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <!-- JDBC backend -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>spanstore-jdbc</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/zipkin-server/src/it/minimal-dependencies/pom.xml
+++ b/zipkin-server/src/it/minimal-dependencies/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.zipkin.java</groupId>
     <artifactId>parent</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.8.1-SNAPSHOT</version>
     <relativePath>../../../..</relativePath>
   </parent>
 


### PR DESCRIPTION
Before, zipkin-server accidentally had a hard dependency on JDBC and
Cassandra. This defers loading these classes until we know they are
there and the feature is enabled.

Fixes #102