### PR TITLE
Backfills missing unit tests for dependency linker

### DIFF
--- a/zipkin/src/main/java/zipkin/SpanStore.java
+++ b/zipkin/src/main/java/zipkin/SpanStore.java
@@ -80,6 +80,10 @@ public interface SpanStore extends SpanConsumer {
    * the original endTs, even when bucketed. Using the daily example, if endTs was 11pm and lookback
    * was 25 hours, the implementation would query against 2 buckets.
    *
+   * <p>Some implementations parse {@link zipkin.internal.DependencyLinkSpan} from storage and call
+   * {@link zipkin.internal.DependencyLinker} to aggregate links. The reason is certain graph logic,
+   * such as skipping up the tree is difficult to implement as a storage query.
+   *
    * @param endTs only return links from spans where {@link Span#timestamp} are at or before this
    *              time in epoch milliseconds.
    * @param lookback only return links from spans where {@link Span#timestamp} are at or after

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinker.java
@@ -36,8 +36,8 @@ public final class DependencyLinker {
   /**
    * @param spans spans where all spans have the same trace id
    */
-  public void putTrace(Iterator<DependencyLinkSpan> spans) {
-    if (!spans.hasNext()) return;
+  public DependencyLinker putTrace(Iterator<DependencyLinkSpan> spans) {
+    if (!spans.hasNext()) return this;
 
     Node.TreeBuilder<DependencyLinkSpan> builder = new Node.TreeBuilder<>();
     while (spans.hasNext()) {
@@ -78,7 +78,7 @@ public final class DependencyLinker {
         }
         parent = parent.parent();
       }
-      if (client == null) continue; // skip if no ancestors were servers
+      if (client == null || server == null) continue; // skip if no ancestors were servers
 
       Pair<String> key = Pair.create(client, server);
       if (linkMap.containsKey(key)) {
@@ -87,6 +87,7 @@ public final class DependencyLinker {
         linkMap.put(key, 1L);
       }
     }
+    return this;
   }
 
   public List<DependencyLink> link() {

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.internal.DependencyLinkSpan.Kind;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyLinkSpanTest {
+
+  @Test
+  public void parentAndChildApply() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L).build();
+    assertThat(span.parentId).isNull();
+    assertThat(span.spanId).isEqualTo(1L);
+
+    span = new DependencyLinkSpan.Builder(1L, 2L).build();
+    assertThat(span.parentId).isEqualTo(1L);
+    assertThat(span.spanId).isEqualTo(2L);
+  }
+
+  /** You cannot make a dependency link unless you know the the local or peer service. */
+  @Test
+  public void whenNoServiceLabelsExist_kindIsUnknown() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L).build();
+
+    assertThat(span.kind).isEqualTo(Kind.UNKNOWN);
+    assertThat(span.peerService).isNull();
+    assertThat(span.service).isNull();
+  }
+
+  @Test
+  public void whenOnlyAddressLabelsExist_kindIsClient() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L)
+        .caService("service1")
+        .saService("service2")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.CLIENT);
+    assertThat(span.service).isEqualTo("service1");
+    assertThat(span.peerService).isEqualTo("service2");
+  }
+
+  /** The linker is biased towards server spans, or client spans that know the peer service. */
+  @Test
+  public void whenServerLabelsAreMissing_kindIsUnknownAndLabelsAreCleared() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L)
+        .caService("service1")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.UNKNOWN);
+    assertThat(span.service).isNull();
+    assertThat(span.peerService).isNull();
+  }
+
+  /** {@link Constants#SERVER_RECV} is only applied when the local span is acting as a server */
+  @Test
+  public void whenSrServiceExists_kindIsServer() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L)
+        .srService("service")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.SERVER);
+    assertThat(span.service).isEqualTo("service");
+    assertThat(span.peerService).isNull();
+  }
+
+  /**
+   * {@link Constants#CLIENT_ADDR} indicates the peer, which is a client in the case of a server
+   * span
+   */
+  @Test
+  public void whenSrAndCaServiceExists_caIsThePeer() {
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L)
+        .caService("service1")
+        .srService("service2")
+        .build();
+
+    assertThat(span.kind).isEqualTo(Kind.SERVER);
+    assertThat(span.service).isEqualTo("service2");
+    assertThat(span.peerService).isEqualTo("service1");
+  }
+
+  @Test
+  public void specialCasesFinagleLocalSocketLabeling() {
+    // Finagle labels two sides of the same socket ("ca", "sa") with the local service name.
+    DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L)
+        .caService("service")
+        .saService("service")
+        .build();
+
+    // When there's no "sr" annotation, we assume it is a client.
+    assertThat(span.kind).isEqualTo(Kind.CLIENT);
+    assertThat(span.service).isNull();
+    assertThat(span.peerService).isEqualTo("service");
+
+    span = new DependencyLinkSpan.Builder(null, 1L)
+        .srService("service")
+        .caService("service")
+        .saService("service")
+        .build();
+
+    // When there is an "sr" annotation, we know it is a server
+    assertThat(span.kind).isEqualTo(Kind.SERVER);
+    assertThat(span.service).isEqualTo("service");
+    assertThat(span.peerService).isNull();
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkerTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.List;
+import org.junit.Test;
+import zipkin.DependencyLink;
+import zipkin.internal.DependencyLinkSpan.Kind;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyLinkerTest {
+
+  @Test
+  public void baseCase() {
+    assertThat(new DependencyLinker().link()).isEmpty();
+  }
+
+  /**
+   * The linker links a directed graph, if the span kind is unknown, we don't know the direction to
+   * link.
+   */
+  @Test
+  public void doesntLinkUnknownRootSpans() {
+    List<DependencyLinkSpan> unknownRootSpans = asList(
+        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, null, null),
+        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, "server", "client"),
+        new DependencyLinkSpan(Kind.UNKNOWN, null, 1L, "client", "server")
+    );
+
+    for (DependencyLinkSpan span : unknownRootSpans) {
+      assertThat(new DependencyLinker()
+          .putTrace(asList(span).iterator()).link())
+          .isEmpty();
+    }
+  }
+
+  /**
+   * A root span can be a client-originated trace or a server receipt which knows its peer. In these
+   * cases, the peer is known and kind establishes the direction.
+   */
+  @Test
+  public void linksSpansDirectedByKind() {
+    List<DependencyLinkSpan> validRootSpans = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "server", "client"),
+        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", "server")
+    );
+
+    for (DependencyLinkSpan span : validRootSpans) {
+      assertThat(new DependencyLinker()
+          .putTrace(asList(span).iterator()).link())
+          .containsOnly(DependencyLink.create("client", "server", 1L));
+    }
+  }
+
+  @Test
+  public void callsAgainstTheSameLinkIncreasesCallCount_span() {
+    List<DependencyLinkSpan> trace = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
+        new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, null, "server"),
+        new DependencyLinkSpan(Kind.CLIENT, 1L, 3L, null, "server")
+    );
+
+    assertThat(new DependencyLinker()
+        .putTrace(trace.iterator()).link())
+        .containsOnly(DependencyLink.create("client", "server", 2L));
+  }
+
+  @Test
+  public void callsAgainstTheSameLinkIncreasesCallCount_trace() {
+    List<DependencyLinkSpan> trace = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
+        new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, null, "server")
+    );
+
+    assertThat(new DependencyLinker()
+        .putTrace(trace.iterator())
+        .putTrace(trace.iterator()).link())
+        .containsOnly(DependencyLink.create("client", "server", 2L));
+  }
+
+  /**
+   * Spans don't always include both the client and server service. When you know the kind, you can
+   * link these without duplicating call count.
+   */
+  @Test
+  public void singleHostSpansResultInASingleCallCount() {
+    List<List<DependencyLinkSpan>> singleLinks = asList(
+        asList(
+            new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", "server"),
+            new DependencyLinkSpan(Kind.SERVER, 1L, 2L, "server", null)
+        ),
+        asList(
+            new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
+            new DependencyLinkSpan(Kind.CLIENT, 1L, 2L, "client", "server")
+        )
+    );
+
+    for (List<DependencyLinkSpan> trace : singleLinks) {
+      assertThat(new DependencyLinker()
+          .putTrace(trace.iterator()).link())
+          .containsOnly(DependencyLink.create("client", "server", 1L));
+    }
+  }
+
+  /**
+   * Spans are sometimes intermediated by an unknown type of span. Prefer the nearest server when
+   * accounting for them.
+   */
+  @Test
+  public void intermediatedClientSpansMissingLocalServiceNameLinkToNearestServer() {
+    List<DependencyLinkSpan> trace = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "client", null),
+        new DependencyLinkSpan(Kind.UNKNOWN, 1L, 2L, null, null), // possibly a local fan-out span
+        new DependencyLinkSpan(Kind.CLIENT, 2L, 3L, null, "server"),
+        new DependencyLinkSpan(Kind.CLIENT, 2L, 4L, null, "server")
+    );
+
+    assertThat(new DependencyLinker()
+        .putTrace(trace.iterator()).link())
+        .containsOnly(DependencyLink.create("client", "server", 2L));
+  }
+
+  /** A loopback span is direction-agnostic, so can be linked properly regardless of kind. */
+  @Test
+  public void linksLoopbackSpans() {
+    List<DependencyLinkSpan> validRootSpans = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "service", "service"),
+        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "service", "service")
+    );
+
+    for (DependencyLinkSpan span : validRootSpans) {
+      assertThat(new DependencyLinker()
+          .putTrace(asList(span).iterator()).link())
+          .containsOnly(DependencyLink.create("service", "service", 1L));
+    }
+  }
+
+  /**
+   * A dependency link is between two services. Given only one span, we cannot link if we don't know
+   * both service names.
+   */
+  @Test
+  public void cannotLinkSingleSpanWithoutBothServiceNames() {
+    List<DependencyLinkSpan> incompleteRootSpans = asList(
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, null, null),
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, "server", null),
+        new DependencyLinkSpan(Kind.SERVER, null, 1L, null, "client"),
+        new DependencyLinkSpan(Kind.CLIENT, null, 1L, null, null),
+        new DependencyLinkSpan(Kind.CLIENT, null, 1L, "client", null),
+        new DependencyLinkSpan(Kind.CLIENT, null, 1L, null, "server")
+    );
+
+    for (DependencyLinkSpan span : incompleteRootSpans) {
+      assertThat(new DependencyLinker()
+          .putTrace(asList(span).iterator()).link())
+          .isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
Problems around dependencies come in two major forms.
* The storage layer, which build DependencyLinkSpans
* The DependencyLinker, which processes DependencyLinkSpans

Before, there wasn't an easy way to separate these problems:
DependenciesTest existed, but was invoked from the storage layer.

By backfilling DependencyLinker tests, problems related to dependency
links can be resolved closer to the code responsible for them.