### PR TITLE
Removes version maintenance from zipkin-server integration tests

### DIFF
--- a/zipkin-server/src/it/minimal-dependencies/pom.xml
+++ b/zipkin-server/src/it/minimal-dependencies/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.zipkin.java</groupId>
     <artifactId>parent</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>@project.version@</version>
     <relativePath>../../../..</relativePath>
   </parent>
 


### PR DESCRIPTION
Before, we had to remember to update the pom to keep the
minimal-dependencies test relevant. This tokenizes it, removing the
maintenance.