### PR TITLE
Updates to zipkin-ui 1.39, notably addressing cache concerns

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <brave.version>3.5.0</brave.version>
-    <zipkin-ui.version>1.38.1</zipkin-ui.version>
+    <zipkin-ui.version>1.39.0</zipkin-ui.version>
     <start-class>zipkin.server.ZipkinServer</start-class>
     <maven-invoker-plugin.version>2.0.0</maven-invoker-plugin.version>
   </properties>

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServerProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServerProperties.java
@@ -13,6 +13,7 @@
  */
 package zipkin.server;
 
+import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin")
@@ -48,6 +49,15 @@ class ZipkinServerProperties {
   static class Ui {
     private String environment;
     private int queryLimit = 10;
+    private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
+
+    public int getDefaultLookback() {
+      return defaultLookback;
+    }
+
+    public void setDefaultLookback(int defaultLookback) {
+      this.defaultLookback = defaultLookback;
+    }
 
     public String getEnvironment() {
       return environment;

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -45,12 +45,15 @@ zipkin:
     lookback: ${QUERY_LOOKBACK:86400000}
   store:
     type: ${STORAGE_TYPE:mem}
-  # Values here are read by Zipkin UI's javascript at /config.json
   ui:
+    ## Values below here are mapped to ZipkinServerProperties.UI, served as /config.json
     # Default limit for Find Traces
     query-limit: 10
     # The value here becomes a label in the top-right corner
     environment:
+    # Default duration to look back when finding traces or dependency links.
+    # Affects the "Start time" element in the UI. 7 days in millis
+    default-lookback: ${QUERY_LOOKBACK:604800000}
 server:
   port: ${QUERY_PORT:9411}
   compression:
@@ -59,6 +62,10 @@ server:
     # Includes dynamic json content and large static assets from zipkin-ui
     mime-types: application/json,application/javascript,text/css,image/svg
 spring:
+  mvc:
+    favicon:
+      # zipkin has its own favicon
+      enabled: false
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mysql://${mysql.host}:${mysql.port}/${mysql.db}?autoReconnect=true&useSSL=${mysql.use-ssl}

--- a/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTests.java
+++ b/zipkin-server/src/test/java/zipkin/server/ZipkinServerIntegrationTests.java
@@ -35,6 +35,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static zipkin.internal.Util.UTF_8;
 
@@ -133,6 +134,17 @@ public class ZipkinServerIntegrationTests {
     mockMvc.perform(get("/api/v1/trace/1?raw"))
         .andExpect(status().isOk())
         .andExpect(content().string(new String(Codec.JSON.writeSpans(asList(span, span)), UTF_8)));
+  }
+
+  /** The zipkin-ui is a single-page app. This prevents reloading all resources on each click. */
+  @Test
+  public void setsMaxAgeOnUiResources() throws Exception {
+    mockMvc.perform(get("/favicon.ico"))
+        .andExpect(header().string("Cache-Control", "max-age=31536000"));
+    mockMvc.perform(get("/config.json"))
+        .andExpect(header().string("Cache-Control", "max-age=600"));
+    mockMvc.perform(get("/index.html"))
+        .andExpect(header().string("Cache-Control", "max-age=60"));
   }
 
   static Span newSpan(long traceId, long id, String spanName, String value, String service) {


### PR DESCRIPTION
zipkin-ui includes some cache-related changes to make the experience
more responsive. It also introduces "Start time", which allows users
to control how far back to search for traces.

This includes a hard-coded cache policy, consistent with zipkin-scala.

* 1 minute for index.html
* 10 minute for /config.json
* 365 days for hashed resources (ex /app-e12b3bbb7e5a572f270d.min.js)

Since index.html links to hashed resource names, any change to it will
orphan old resources. That's why hashed resource age can be 365 days.

See #1062