### PR TITLE
Define elasticsearch hosts property as a List<String> instead of comm…

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinElasticsearchProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinElasticsearchProperties.java
@@ -13,6 +13,8 @@
  */
 package zipkin.server;
 
+import java.util.Collections;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("elasticsearch")
@@ -24,11 +26,10 @@ public class ZipkinElasticsearchProperties {
   private String cluster = "elasticsearch";
 
   /**
-   * A comma separated list of elasticsearch hostnodes to connect to, in host:port
-   * format. The port should be the transport port, not the http port. Defaults to
-   * "localhost:9300".
+   * A list of elasticsearch hostnodes to connect to, in host:port format. The port should be the
+   * transport port, not the http port. Defaults to "localhost:9300".
    */
-  private String hosts = "localhost:9300";
+  private List<String> hosts = Collections.singletonList("localhost:9300");
 
   /**
    * The index prefix to use when generating daily index names. Defaults to zipkin.
@@ -44,11 +45,11 @@ public class ZipkinElasticsearchProperties {
     return this;
   }
 
-  public String getHosts() {
+  public List<String> getHosts() {
     return hosts;
   }
 
-  public ZipkinElasticsearchProperties setHosts(String hosts) {
+  public ZipkinElasticsearchProperties setHosts(List<String> hosts) {
     this.hosts = hosts;
     return this;
   }

--- a/zipkin-spanstores/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchConfig.java
+++ b/zipkin-spanstores/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchConfig.java
@@ -16,6 +16,8 @@ package zipkin.elasticsearch;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 
 import static zipkin.internal.Util.checkNotNull;
 
@@ -24,7 +26,7 @@ public class ElasticsearchConfig {
   public static final class Builder {
 
     private String cluster = "elasticsearch";
-    private String hosts = "localhost:9300";
+    private List<String> hosts = Collections.singletonList("localhost:9300");
     private String index = "zipkin";
 
     /**
@@ -39,7 +41,7 @@ public class ElasticsearchConfig {
      * A comma separated list of elasticsearch hostnodes to connect to, in host:port format. The
      * port should be the transport port, not the http port. Defaults to "localhost:9300".
      */
-    public Builder hosts(String hosts) {
+    public Builder hosts(List<String> hosts) {
       this.hosts = hosts;
       return this;
     }
@@ -58,7 +60,7 @@ public class ElasticsearchConfig {
   }
 
   final String clusterName;
-  final String hosts;
+  final List<String> hosts;
   final String index;
   final String indexTemplate;
 

--- a/zipkin-spanstores/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-spanstores/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchSpanStore.java
@@ -454,7 +454,7 @@ public class ElasticsearchSpanStore implements GuavaSpanStore {
         .actionGet();
   }
 
-  private static Client createClient(String hosts, String clusterName) {
+  private static Client createClient(List<String> hosts, String clusterName) {
     Settings settings = Settings.builder()
         .put("cluster.name", clusterName)
         .put("client.transport.sniff", true)
@@ -463,7 +463,7 @@ public class ElasticsearchSpanStore implements GuavaSpanStore {
     TransportClient client = TransportClient.builder()
         .settings(settings)
         .build();
-    for (String host : hosts.split(",")) {
+    for (String host : hosts) {
       HostAndPort hostAndPort = HostAndPort.fromString(host);
       try {
         client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(


### PR DESCRIPTION
…a-separated list String. spring-boot handles the conversion correctly, even for environment variables defined as a comma-separated list.