### PR TITLE
Prevents Kafka processing from halting on storage errors

### DIFF
--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -33,7 +33,7 @@
     <libthrift.version>0.9.3</libthrift.version>
     <scalatest.version>2.2.5</scalatest.version>
     <!-- Which implementation version are the span stores compatible with -->
-    <zipkin-scala.version>1.38.1</zipkin-scala.version>
+    <zipkin-scala.version>1.39.0</zipkin-scala.version>
   </properties>
 
   <dependencies>

--- a/zipkin-spanstores/cassandra/pom.xml
+++ b/zipkin-spanstores/cassandra/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <zipkin-cassandra-core.version>1.38.0</zipkin-cassandra-core.version>
+    <zipkin-cassandra-core.version>1.39.0</zipkin-cassandra-core.version>
   </properties>
 
   <dependencies>

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
@@ -15,6 +15,7 @@ package zipkin.kafka;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 import kafka.serializer.Decoder;
 import zipkin.Codec;
 import zipkin.Span;
@@ -24,6 +25,7 @@ import zipkin.Span;
  * list. Malformed input is ignored.
  */
 final class SpansDecoder implements Decoder<List<Span>> {
+  final Logger logger = Logger.getLogger(SpansDecoder.class.getName());
 
   @Override
   public List<Span> fromBytes(byte[] bytes) {
@@ -44,8 +46,8 @@ final class SpansDecoder implements Decoder<List<Span>> {
       } else {
         return Collections.singletonList(Codec.THRIFT.readSpan(bytes));
       }
-    } catch (IllegalArgumentException ignored) {
-      // binary decoding messages aren't useful enough to clutter logs with.
+    } catch (RuntimeException e) {
+      logger.fine("malformed message: " + e.getMessage());
       return Collections.emptyList();
     }
   }


### PR DESCRIPTION
While not documented, and possibly not intentional, `SpanStore.apply`
can throw. For example, we found that a span too large to store resulted
in an exception like below, which halted all further Kafka processing.

```
com.datastax.driver.core.exceptions.InvalidQueryException: Key length of 97122 is longer than maximum of 65535
```

This changes logic to skip and log error on any exception. To prevent
logs from filling up, the error message only includes ids.

This is a copy of https://github.com/openzipkin/zipkin/pull/1070