### PR TITLE
Fixes guava version at 18 so as to avoid method not found errors

### DIFF
--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -63,12 +63,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>spanstore-guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>spanstore-cassandra</artifactId>
       <scope>test</scope>
     </dependency>
@@ -84,15 +78,6 @@
       <artifactId>spanstore-jdbc</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- Force guava version to 19.0 for elasticsearch because zipkin-common uses 16.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
-      <scope>test</scope>
-    </dependency>
-
 
     <!-- Dependencies for SpanStoreSpec -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,10 @@
     <mariadb-java-client.version>1.3.6</mariadb-java-client.version>
     <elasticsearch.version>2.2.1</elasticsearch.version>
     <slf4j.version>1.7.19</slf4j.version>
-    <guava.version>19.0</guava.version>
+    <!-- be careful to not eagerly update as we can break other storage or transports!
+         This is set to the lowest possible version. Elasticsearch requires guava 18
+    -->
+    <guava.version>18.0</guava.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <assertj.version>3.3.0</assertj.version>
@@ -184,6 +187,12 @@
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
         <version>${okio.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <dependency>

--- a/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
+++ b/zipkin-spanstores/cassandra/src/main/java/zipkin/cassandra/CassandraSpanStore.java
@@ -44,7 +44,6 @@ import zipkin.spanstore.guava.GuavaToAsyncSpanStoreAdapter;
 
 import static com.google.common.util.concurrent.Futures.allAsList;
 import static com.google.common.util.concurrent.Futures.transform;
-import static com.google.common.util.concurrent.Futures.transformAsync;
 import static java.lang.String.format;
 import static zipkin.cassandra.CassandraUtil.annotationKeys;
 import static zipkin.cassandra.CassandraUtil.intersectKeySets;
@@ -120,7 +119,7 @@ public final class CassandraSpanStore extends GuavaToAsyncSpanStoreAdapter
       // We achieve the AND goal, by intersecting each of the key sets.
       traceIds = transform(allAsList(futureKeySetsToIntersect), intersectKeySets());
     }
-    return transformAsync(traceIds, new AsyncFunction<Set<Long>, List<List<Span>>>() {
+    return transform(traceIds, new AsyncFunction<Set<Long>, List<List<Span>>>() {
       @Override
       public ListenableFuture<List<List<Span>>> apply(Set<Long> traceIds) {
         return transform(repository.getSpansByTraceIds(traceIds.toArray(new Long[traceIds.size()]),

--- a/zipkin-spanstores/guava/pom.xml
+++ b/zipkin-spanstores/guava/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This sets a floor version of guava 18, which is bound by elasticsearch.

This will prevent us from accidentally using new signatures, causing errors like this:

```
com.google.common.util.concurrent.Futures.transformAsync(Lcom/google/common/util/concurrent/ListenableFuture;Lcom/google/common/util/concurrent/AsyncFunction;)Lcom/google/common/util/concurrent/ListenableFuture;] with root cause
```