### PR TITLE
Makes JDBC initialization dependent on storage type

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinMySQLProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinMySQLProperties.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("mysql")
+public class ZipkinMySQLProperties {
+  private String host = "localhost";
+  private int port = 3306;
+  private String username;
+  private String password;
+  private String db = "zipkin";
+  private int maxActive = 10;
+  private boolean useSsl;
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = "".equals(username) ? null : username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = "".equals(password) ? null : password;
+  }
+
+  public String getDb() {
+    return db;
+  }
+
+  public void setDb(String db) {
+    this.db = db;
+  }
+
+  public int getMaxActive() {
+    return maxActive;
+  }
+
+  public void setMaxActive(int maxActive) {
+    this.maxActive = maxActive;
+  }
+
+  public boolean isUseSsl() {
+    return useSsl;
+  }
+
+  public void setUseSsl(boolean useSsl) {
+    this.useSsl = useSsl;
+  }
+}

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -66,15 +66,10 @@ spring:
     favicon:
       # zipkin has its own favicon
       enabled: false
-  datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mysql://${mysql.host}:${mysql.port}/${mysql.db}?autoReconnect=true&useSSL=${mysql.use-ssl}
-    username: ${mysql.username}
-    password: ${mysql.password}
-    max-active: ${mysql.max-active}
-    schema: classpath:/mysql.sql
-# Switch this on to create the schema on startup:
-    initialize: false
+  autoconfigure:
+    exclude:
+      # otherwise we might initialize even when not needed (ex when storage type is cassandra)
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 # Example of how to log cassandra calls
 # logging:
 #     level:


### PR DESCRIPTION
Before, auto-configuration would initialize JDBC even when the storage
type was cassandra. This caused the health check to false negative.

One way attempted was to move the yaml config to inside zipkin as
opposed to spring. However, this still ended up being read by auto-
configuration. The end result was making this use the same properties
approach as other storage services, disabling auto-configuration in the
yaml file.

This helps us move towards better modularity #108 

Fixes #137