### PR TITLE
Attempts to de-flake Kafka transport tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ _site/
 .idea
 *.iml
 *.swp
-# .travis.yml installs cassandra in the pwd
+# .travis.yml installs things
 dsc-cassandra-*
+elasticsearch-*
+kafka_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ before_install:
   - curl -SL https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.1/elasticsearch-2.2.1.tar.gz | tar xz
   - elasticsearch-*/bin/elasticsearch -d > /dev/null
 
+  # Manually install and run zk+kafka as it isn't an available service
+  - curl -SL http://www.us.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz | tar xz
+  - nohup bash -c "cd kafka_* && bin/zookeeper-server-start.sh config/zookeeper.properties >/dev/null 2>&1 &"
+  - nohup bash -c "cd kafka_* && bin/kafka-server-start.sh config/server.properties >/dev/null 2>&1 &"
+
 script:
   # If we aren't a pull request, we are publishing either a snapshot or a release.
   #   We don't currently publish the benchmarks or interop modules, as they are test code only.

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <mariadb-java-client.version>1.3.6</mariadb-java-client.version>
     <elasticsearch.version>2.2.1</elasticsearch.version>
     <slf4j.version>1.7.19</slf4j.version>
+    <logback.version>1.1.6</logback.version>
     <!-- be careful to not eagerly update as we can break other storage or transports!
          This is set to the lowest possible version. Elasticsearch requires guava 18
     -->
@@ -321,6 +322,7 @@
             <exclude>**/*.md</exclude>
             <exclude>dsc-cassandra-*/**</exclude>
             <exclude>elasticsearch-*/**</exclude>
+            <exclude>kafka_*/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>
           </excludes>

--- a/zipkin-spanstores/elasticsearch/pom.xml
+++ b/zipkin-spanstores/elasticsearch/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.6</version>
+      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zipkin-transports/kafka/pom.xml
+++ b/zipkin-transports/kafka/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -31,8 +33,6 @@
     <!-- This is pinned to Kafka 0.8.x client as 0.9.x brokers work with them, but not visa-versa
          http://docs.confluent.io/2.0.0/upgrade.html -->
     <kafka.version>0.8.2.2</kafka.version>
-    <!-- pinned to 0.8.2.2 -->
-    <kafka-junit.version>1.7</kafka-junit.version>
   </properties>
 
   <dependencies>
@@ -45,24 +45,19 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
       <version>${kafka.version}</version>
-      <!-- excludes eagerly bound logger dependencies,
-           so that they don't leak into zipkin-server -->
+      <!-- don't eagerly bind slf4j -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
     <dependency>
-      <groupId>com.github.charithe</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <version>${kafka-junit.version}</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaTransport.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaTransport.java
@@ -29,13 +29,14 @@ import static kafka.consumer.Consumer.createJavaConsumerConnector;
  */
 public final class KafkaTransport implements AutoCloseable {
 
+  final ConsumerConnector connector;
   final ExecutorService pool;
 
   public KafkaTransport(KafkaConfig config, AsyncSpanConsumer spanConsumer) {
     this.pool = config.streams == 1
         ? Executors.newSingleThreadExecutor()
         : Executors.newFixedThreadPool(config.streams);
-    ConsumerConnector connector = createJavaConsumerConnector(config.forConsumer());
+    connector = createJavaConsumerConnector(config.forConsumer());
 
     Map<String, Integer> topicCountMap = new LinkedHashMap<>(1);
     topicCountMap.put(config.topic, config.streams);
@@ -49,5 +50,6 @@ public final class KafkaTransport implements AutoCloseable {
   @Override
   public void close() {
     pool.shutdown();
+    connector.shutdown();
   }
 }

--- a/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaTestGraph.java
+++ b/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaTestGraph.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.kafka;
+
+import java.util.Properties;
+import kafka.common.FailedToSendMessageException;
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.exception.ZkTimeoutException;
+import org.junit.AssumptionViolatedException;
+
+/** Tests only execute when ZK and Kafka are listening on 127.0.0.1 on default ports. */
+enum KafkaTestGraph {
+  INSTANCE;
+
+  private AssumptionViolatedException ex;
+  private Producer<String, byte[]> producer;
+
+  synchronized Producer<String, byte[]> producer() {
+    if (ex != null) throw ex;
+    if (this.producer == null) {
+      Properties producerProps = new Properties();
+      producerProps.put("metadata.broker.list", "127.0.0.1:9092");
+      producerProps.put("producer.type", "sync");
+      producer = new Producer<>(new ProducerConfig(producerProps));
+      try {
+        new ZkClient("127.0.0.1:2181", 1000);
+        producer.send(new KeyedMessage<>("test", new byte[0]));
+      } catch (FailedToSendMessageException | ZkTimeoutException e) {
+        throw ex = new AssumptionViolatedException(e.getMessage());
+      }
+    }
+    return producer;
+  }
+}

--- a/zipkin-transports/kafka/src/test/resources/log4j.properties
+++ b/zipkin-transports/kafka/src/test/resources/log4j.properties
@@ -6,7 +6,3 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.appender.A1.ImmediateFlush=true
-
-log4j.logger.kafka.utils=WARN, A1
-log4j.logger.kafka.consumer=WARN, A1
-log4j.logger.kafka.producer=WARN, A1

--- a/zipkin-transports/kafka/src/test/resources/logback.xml
+++ b/zipkin-transports/kafka/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- don't waste logs when ZK check fails -->
+  <logger name="org.apache.zookeeper.ClientCnxn" level="OFF"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Kafka tests were failing on master. This does a few things to help:
* Starts ZK+Kafka in travis as opposed to via test lifecycle
* Don't exclude log4j: this is actually used by Kafka!
* Configure logback
* Don't try to use "localhost", which can fail. Use 127.0.0.1
* Close more resources
* Sets a hard timeout of 10 seconds to run all Kafka tests
* Ignores `skipsOnConsumerException` test for now, as breaks travis