### PR TITLE
Adds debug logging for DependencyLinker

### DIFF
--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -70,7 +70,9 @@ spring:
     exclude:
       # otherwise we might initialize even when not needed (ex when storage type is cassandra)
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-# Example of how to log cassandra calls
 # logging:
-#     level:
-#         org.twitter.zipkin.storage.cassandra.Repository: 'DEBUG'
+#   level:
+#     # investigate /api/v1/dependencies
+#     zipkin.internal.DependencyLinker: 'DEBUG'
+#     # log cassandra calls
+#     org.twitter.zipkin.storage.cassandra.Repository: 'DEBUG'

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
@@ -13,6 +13,7 @@
  */
 package zipkin.internal;
 
+import static java.lang.String.format;
 import static zipkin.internal.Util.checkNotNull;
 import static zipkin.internal.Util.equal;
 
@@ -36,18 +37,29 @@ public final class DependencyLinkSpan {
   final Kind kind;
   @Nullable
   final Long parentId;
-  final long spanId;
+  final long id;
   @Nullable
   final String service;
   @Nullable
   final String peerService;
 
-  DependencyLinkSpan(Kind kind, Long parentId, long spanId, String service, String peerService) {
+  DependencyLinkSpan(Kind kind, Long parentId, long id, String service, String peerService) {
     this.kind = checkNotNull(kind, "kind");
     this.parentId = parentId;
-    this.spanId = spanId;
+    this.id = id;
     this.service = service;
     this.peerService = peerService;
+  }
+
+  @Override public String toString() {
+    StringBuilder json = new StringBuilder("{\"kind\": ").append(kind).append("");
+    if (parentId != null) {
+      json.append(", \"parentId\": ").append(format("%016x", parentId)).append("");
+    }
+    json.append(", \"id\": ").append(format("%016x", id)).append("");
+    if (service != null) json.append(", \"service\": ").append(service).append("");
+    if (peerService != null) json.append(", \"peerService\": ").append(peerService).append("");
+    return json.append("}").toString();
   }
 
   public static final class Builder {

--- a/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
+++ b/zipkin/src/test/java/zipkin/internal/DependencyLinkSpanTest.java
@@ -22,14 +22,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DependencyLinkSpanTest {
 
   @Test
+  public void testToString() {
+    assertThat(new DependencyLinkSpan.Builder(null, 1L).build())
+        .hasToString("{\"kind\": UNKNOWN, \"id\": 0000000000000001}");
+
+    assertThat(new DependencyLinkSpan.Builder(1L, 2L).build())
+        .hasToString("{\"kind\": UNKNOWN, \"parentId\": 0000000000000001, \"id\": 0000000000000002}");
+
+    assertThat(new DependencyLinkSpan.Builder(1L, 2L)
+        .srService("processor")
+        .caService("kinesis").build())
+        .hasToString("{\"kind\": SERVER, \"parentId\": 0000000000000001, \"id\": 0000000000000002, \"service\": processor, \"peerService\": kinesis}");
+
+    // It is invalid to log "ca" without "sr", so marked as unknown
+    assertThat(new DependencyLinkSpan.Builder(1L, 2L)
+        .caService("kinesis").build())
+        .hasToString("{\"kind\": UNKNOWN, \"parentId\": 0000000000000001, \"id\": 0000000000000002}");
+
+    assertThat(new DependencyLinkSpan.Builder(1L, 2L)
+        .saService("mysql").build())
+        .hasToString("{\"kind\": CLIENT, \"parentId\": 0000000000000001, \"id\": 0000000000000002, \"peerService\": mysql}");
+
+    // arbitrary 2-sided span
+    assertThat(new DependencyLinkSpan.Builder(1L, 2L)
+        .caService("shell-script")
+        .saService("mysql").build())
+        .hasToString("{\"kind\": CLIENT, \"parentId\": 0000000000000001, \"id\": 0000000000000002, \"service\": shell-script, \"peerService\": mysql}");
+  }
+
+  @Test
   public void parentAndChildApply() {
     DependencyLinkSpan span = new DependencyLinkSpan.Builder(null, 1L).build();
     assertThat(span.parentId).isNull();
-    assertThat(span.spanId).isEqualTo(1L);
+    assertThat(span.id).isEqualTo(1L);
 
     span = new DependencyLinkSpan.Builder(1L, 2L).build();
     assertThat(span.parentId).isEqualTo(1L);
-    assertThat(span.spanId).isEqualTo(2L);
+    assertThat(span.id).isEqualTo(2L);
   }
 
   /** You cannot make a dependency link unless you know the the local or peer service. */


### PR DESCRIPTION
It can be vexing to troubleshoot why the dependency graph isn't working
out as expected. This adds log messages describing which spans were
involved in which links.