### PR TITLE
Applied merging for in memory span store

### DIFF
--- a/zipkin/src/main/java/zipkin/InMemorySpanStore.java
+++ b/zipkin/src/main/java/zipkin/InMemorySpanStore.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
 import zipkin.async.AsyncSpanConsumer;
 import zipkin.async.AsyncSpanStore;
 import zipkin.async.Callback;
@@ -208,9 +209,9 @@ public final class InMemorySpanStore implements SpanStore, AsyncSpanStore, Async
 
     for (Collection<Span> trace : traceIdToSpans.delegate.values()) {
       if (trace.isEmpty()) continue;
-
+      Collection<Span> mergedSpans = CorrectForClockSkew.apply(MergeById.apply(trace));
       List<DependencyLinkSpan> linkSpans = new LinkedList<>();
-      for (Span s : trace) {
+      for (Span s : mergedSpans) {
         Long timestamp = s.timestamp;
         if (timestamp == null ||
             timestamp < (endTs - lookback) ||


### PR DESCRIPTION
I had some issues in Sleuth with the dependency graph, the graph wasn't displayed properly after clicking around in the application. 

HOWEVER, if I took the spans from Zipkin (/trace/...) and POSTed them back to the app the graph was working fine.

I checked the difference between the spans returned by Zipkin and those that it operates on while trying to build the graph and I saw that this was missing:

` Collection<Span> mergedSpans = CorrectForClockSkew.apply(MergeById.apply(trace));`

Now the graph looks fine. I hope that I'm not applying a hack or sth like that ;)