### PR TITLE
Tests that empty binary annotation values don't crash

### DIFF
--- a/zipkin/src/test/java/zipkin/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/SpanStoreTest.java
@@ -392,6 +392,25 @@ public abstract class SpanStoreTest {
         .containsExactly(asList(barAndFooAndBazAndQux));
   }
 
+  /** Make sure empty binary annotation values don't crash */
+  @Test
+  public void getTraces_binaryAnnotationWithEmptyValue() {
+    Span span = new Span.Builder()
+        .traceId(1)
+        .name("call1")
+        .id(1)
+        .timestamp((today + 1) * 1000)
+        .addBinaryAnnotation(BinaryAnnotation.create("empty", "", ep)).build();
+
+    store(span);
+
+    assertThat(store().getTraces((new QueryRequest.Builder("service").build())))
+        .containsExactly(asList(span));
+
+    assertThat(store().getTrace(1L))
+        .containsExactly(span);
+  }
+
   /**
    * It is expected that [[com.twitter.zipkin.storage.SpanStore.apply]] will receive the same span
    * id multiple times with different annotations. At query time, these must be merged.


### PR DESCRIPTION
ensures that https://github.com/openzipkin/zipkin/issues/1073 doesn't impact this codebase