### PR TITLE
Unwinds inheritance of InMemorySpanStore

### DIFF
--- a/interop/src/test/java/zipkin/InMemoryScalaSpanStoreTest.java
+++ b/interop/src/test/java/zipkin/InMemoryScalaSpanStoreTest.java
@@ -15,13 +15,18 @@ package zipkin;
 
 import com.twitter.zipkin.storage.SpanStore;
 import com.twitter.zipkin.storage.SpanStoreSpec;
+import zipkin.async.AsyncSpanConsumer;
+import zipkin.async.BlockingToAsyncSpanConsumerAdapter;
+import zipkin.async.BlockingToAsyncSpanStoreAdapter;
 import zipkin.interop.AsyncToScalaSpanStoreAdapter;
 
 public class InMemoryScalaSpanStoreTest extends SpanStoreSpec {
-  private InMemorySpanStore mem = new InMemorySpanStore();
+  InMemorySpanStore mem = new InMemorySpanStore();
+  BlockingToAsyncSpanStoreAdapter store = new BlockingToAsyncSpanStoreAdapter(mem, Runnable::run);
+  AsyncSpanConsumer consumer = new BlockingToAsyncSpanConsumerAdapter(mem::accept, Runnable::run);
 
   public SpanStore store() {
-    return new AsyncToScalaSpanStoreAdapter(mem, mem);
+    return new AsyncToScalaSpanStoreAdapter(store, consumer);
   }
 
   public void clear() {

--- a/interop/src/test/java/zipkin/elasticsearch/ElasticsearchScalaDependencyStoreTest.java
+++ b/interop/src/test/java/zipkin/elasticsearch/ElasticsearchScalaDependencyStoreTest.java
@@ -21,6 +21,9 @@ import org.junit.BeforeClass;
 import scala.collection.immutable.List;
 import zipkin.DependencyLink;
 import zipkin.InMemorySpanStore;
+import zipkin.async.AsyncSpanConsumer;
+import zipkin.async.BlockingToAsyncSpanConsumerAdapter;
+import zipkin.async.BlockingToAsyncSpanStoreAdapter;
 import zipkin.interop.AsyncToScalaSpanStoreAdapter;
 import zipkin.interop.ScalaDependencyStoreAdapter;
 
@@ -41,7 +44,9 @@ public class ElasticsearchScalaDependencyStoreTest extends DependencyStoreSpec {
   @Override
   public void processDependencies(List<Span> input) {
     InMemorySpanStore mem = new InMemorySpanStore();
-    new AsyncToScalaSpanStoreAdapter(mem, mem).apply(input);
+    BlockingToAsyncSpanStoreAdapter store = new BlockingToAsyncSpanStoreAdapter(mem, Runnable::run);
+    AsyncSpanConsumer consumer = new BlockingToAsyncSpanConsumerAdapter(mem::accept, Runnable::run);
+    new AsyncToScalaSpanStoreAdapter(store, consumer).apply(input);
     java.util.List<DependencyLink>
         links = mem.getDependencies(today() + TimeUnit.DAYS.toMillis(1), null);
 

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinUiConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinUiConfiguration.java
@@ -58,13 +58,13 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  * That's why hashed resource age can be 365 days.
  */
 @Configuration
-@EnableConfigurationProperties(ZipkinUIProperties.class)
+@EnableConfigurationProperties(ZipkinUiProperties.class)
 @RestController
 @ConditionalOnResource(resources = "classpath:zipkin-ui") // from io.zipkin:zipkin-ui
 public class ZipkinUiConfiguration extends WebMvcConfigurerAdapter {
 
   @Autowired
-  ZipkinUIProperties ui;
+  ZipkinUiProperties ui;
   @Value("classpath:zipkin-ui/index.html")
   Resource indexHtml;
 
@@ -100,7 +100,7 @@ public class ZipkinUiConfiguration extends WebMvcConfigurerAdapter {
   }
 
   @RequestMapping(value = "/config.json", method = GET, produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<ZipkinUIProperties> serveUiConfig() {
+  public ResponseEntity<ZipkinUiProperties> serveUiConfig() {
     return ResponseEntity.ok()
         .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES))
         .body(ui);

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinUiProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinUiProperties.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.ui")
-public class ZipkinUIProperties {
+public class ZipkinUiProperties {
   private String environment;
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);

--- a/zipkin/src/test/java/zipkin/InMemorySpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/InMemorySpanStoreTest.java
@@ -14,12 +14,13 @@
 package zipkin;
 
 import zipkin.async.AsyncSpanConsumer;
+import zipkin.async.BlockingToAsyncSpanConsumerAdapter;
 
 public class InMemorySpanStoreTest extends SpanStoreTest {
   private final InMemorySpanStore store = new InMemorySpanStore();
 
   @Override protected AsyncSpanConsumer consumer() {
-    return store;
+    return new BlockingToAsyncSpanConsumerAdapter(store::accept, Runnable::run);
   }
 
   @Override protected SpanStore store() {


### PR DESCRIPTION
Particularly when using Spring, multiple inheritance can confuse things.
For example, if InMemorySpanStore implements AsyncSpanConsumer, and
another bean does, too, the user will have to explicitly choose which
they want. This complexity isn't helpful.

This unwinds `InMemorySpanStore` to only implement `SpanStore` directly.
In the near future, we will move to a component model which should
reduce this type of concern.

See #135