### PR TITLE
Re-adds Scribe transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
 
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>transport-scribe</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-server</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -18,10 +18,11 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
 
 The following environment variables from zipkin-scala are honored.
 
-    * `QUERY_PORT`: Listen lookback for the query http api; Defaults to 9411
+    * `QUERY_PORT`: Listen port for the http api and web ui; Defaults to 9411
     * `QUERY_LOG_LEVEL`: Log level written to the console; Defaults to INFO
     * `QUERY_LOOKBACK`: How many milliseconds queries look back from endTs; Defaults to 7 days
     * `STORAGE_TYPE`: SpanStore implementation: one of `mem` or `mysql`
+    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410 
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
 ### Cassandra

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -126,6 +126,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Scribe transport -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>transport-scribe</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Trace api controller activity with Brave -->
     <dependency>
       <groupId>com.github.kristofa</groupId>

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinScribeProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinScribeProperties.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("scribe")
+class ZipkinScribeProperties {
+  private String category = "zipkin";
+  private int port = 9410;
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+}

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -36,6 +36,9 @@ kafka:
   group-id: ${KAFKA_GROUP_ID:zipkin}
   # Count of consumer threads consuming the topic
   streams: ${KAFKA_STREAMS:1}
+scribe:
+  category: zipkin
+  port: ${COLLECTOR_PORT:9410}
 zipkin:
   collector:
     # percentage to traces to retain
@@ -70,8 +73,10 @@ spring:
     exclude:
       # otherwise we might initialize even when not needed (ex when storage type is cassandra)
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-# logging:
-#   level:
+logging:
+  level:
+    # Silence Invalid method name: '__can__finagle__trace__v3__'
+    com.facebook.swift.service.ThriftServiceProcessor: 'OFF'
 #     # investigate /api/v1/dependencies
 #     zipkin.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra calls

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaStreamProcessor.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaStreamProcessor.java
@@ -34,7 +34,7 @@ final class KafkaStreamProcessor implements Runnable {
   public void run() {
     ConsumerIterator<String, List<Span>> messages = stream.iterator();
     while (messages.hasNext()) {
-      List<Span> spans = messages.next().message();
+      final List<Span> spans = messages.next().message();
       if (spans.isEmpty()) continue;
       try {
         spanConsumer.accept(spans, logger.acceptSpansCallback(spans));

--- a/zipkin-transports/scribe/README.md
+++ b/zipkin-transports/scribe/README.md
@@ -1,0 +1,19 @@
+# transport-scribe
+This transport accepts Scribe logs in a specified category. Each log
+entry is expected to contain a single span, which is TBinaryProtocol
+big-endian, then base64 encoded. These spans are then pushed to storage.
+
+`zipkin.scribe.ScribeConfig` includes defaults that will listen on port
+9410, accept log entries in the category "zipkin"
+
+### Encoding
+The scribe message is a TBinaryProtocol big-endian, then Base64 span.
+Base64 Basic and MIME schemes are supported.
+
+Here's what it looks like in pseudocode
+```
+serialized = writeTBinaryProtocol(span)
+encoded = base64(serialized)
+
+scribe.log(category = "zipkin", message = encoded)
+```

--- a/zipkin-transports/scribe/pom.xml
+++ b/zipkin-transports/scribe/pom.xml
@@ -19,16 +19,33 @@
 
   <parent>
     <groupId>io.zipkin.java</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>zipkin-transports</artifactId>
     <version>0.10.5-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-transports</artifactId>
-  <name>Zipkin Span Transports</name>
-  <packaging>pom</packaging>
+  <artifactId>transport-scribe</artifactId>
+  <name>Span Transport: Scribe</name>
 
-  <modules>
-    <module>scribe</module>
-    <module>kafka</module>
-  </modules>
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <swift.version>0.18.0</swift.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>storage-guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.facebook.swift</groupId>
+      <artifactId>swift-service</artifactId>
+      <version>${swift.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/Scribe.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/Scribe.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.scribe;
+
+import com.facebook.swift.codec.ThriftEnumValue;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.List;
+
+@ThriftService("Scribe")
+public interface Scribe {
+
+  @ThriftMethod(value = "Log") ListenableFuture<ResultCode> log(
+      @ThriftField(value = 1) List<LogEntry> messages);
+
+  enum ResultCode {
+    OK(0), TRY_LATER(1);
+
+    final int value;
+
+    ResultCode(int value) {
+      this.value = value;
+    }
+
+    @ThriftEnumValue
+    public int value() {
+      return value;
+    }
+  }
+
+  @ThriftStruct(value = "LogEntry")
+  final class LogEntry {
+
+    @ThriftField(value = 1)
+    public String category;
+
+    @ThriftField(value = 2)
+    public String message;
+  }
+}

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeConfig.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeConfig.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.scribe;
+
+import com.facebook.swift.service.ThriftServerConfig;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/** Configuration including defaults needed to receive spans from a Scribe category. */
+public final class ScribeConfig {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String category = "zipkin";
+    private int port = 9410;
+
+    /** Category zipkin spans will be consumed from. Defaults to "zipkin" */
+    public Builder category(String category) {
+      this.category = category;
+      return this;
+    }
+
+    /** The port to listen on. Defaults to 9410 */
+    public Builder port(int port) {
+      this.port = port;
+      return this;
+    }
+
+    public ScribeConfig build() {
+      return new ScribeConfig(this);
+    }
+  }
+
+  final String category;
+  final int port;
+
+  ScribeConfig(Builder builder) {
+    this.category = checkNotNull(builder.category, "category");
+    this.port = builder.port;
+  }
+
+  ThriftServerConfig forThriftServer() {
+    return new ThriftServerConfig().setPort(port);
+  }
+}

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeSpanConsumer.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeSpanConsumer.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.scribe;
+
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+import zipkin.AsyncSpanConsumer;
+import zipkin.Callback;
+import zipkin.Codec;
+import zipkin.Span;
+import zipkin.internal.SpanConsumerLogger;
+
+import static zipkin.internal.Util.checkNotNull;
+
+final class ScribeSpanConsumer implements Scribe {
+  final SpanConsumerLogger logger = new SpanConsumerLogger(ScribeSpanConsumer.class);
+  final AsyncSpanConsumer spanConsumer;
+  final String category;
+
+  ScribeSpanConsumer(AsyncSpanConsumer spanConsumer, String category) {
+    this.spanConsumer = checkNotNull(spanConsumer, "spanConsumer");
+    this.category = checkNotNull(category, "category");
+  }
+
+  @Override
+  public ListenableFuture<ResultCode> log(List<LogEntry> messages) {
+    List<Span> spans;
+    try {
+      spans = messages.stream()
+          .filter(m -> m.category.equals(category))
+          .map(e -> Base64.getMimeDecoder().decode(e.message)) // finagle-zipkin uses mime encoding
+          .map(Codec.THRIFT::readSpan)
+          .filter(s -> s != null).collect(Collectors.toList());
+    } catch (RuntimeException e) {
+      logger.errorDecoding(e);
+      return Futures.immediateFailedFuture(e);
+    }
+
+    if (spans.isEmpty()) return Futures.immediateFuture(ResultCode.OK);
+
+    ErrorLoggingFuture result = new ErrorLoggingFuture(logger, spans);
+    try {
+      spanConsumer.accept(spans, result);
+    } catch (RuntimeException e) {
+      result.onError(e);
+    }
+    return result;
+  }
+
+  static final class ErrorLoggingFuture extends AbstractFuture<ResultCode>
+      implements Callback<Void> {
+    final SpanConsumerLogger logger;
+    final List<Span> spans;
+
+    ErrorLoggingFuture(SpanConsumerLogger logger, List<Span> spans) {
+      this.logger = logger;
+      this.spans = spans;
+    }
+
+    @Override public void onSuccess(Void value) {
+      set(ResultCode.OK);
+    }
+
+    @Override public void onError(Throwable t) {
+      logger.errorAcceptingSpans(spans, t);
+      setException(t);
+    }
+  }
+}

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeTransport.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeTransport.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.scribe;
+
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.service.ThriftServer;
+import com.facebook.swift.service.ThriftServiceProcessor;
+import zipkin.AsyncSpanConsumer;
+import zipkin.spanstore.guava.GuavaSpanConsumer;
+
+import static java.util.Collections.emptyList;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * This transport accepts Scribe logs in a specified category. Each log entry is expected to contain
+ * a single span, which is TBinaryProtocol big-endian, then base64 encoded. These spans are chained
+ * to an {@link GuavaSpanConsumer#accept asynchronous span consumer}.
+ */
+public final class ScribeTransport implements AutoCloseable {
+  final ThriftServer server;
+
+  public ScribeTransport(ScribeConfig config, AsyncSpanConsumer consumer) {
+    checkNotNull(config, "config");
+    checkNotNull(consumer, "consumer");
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, config.category);
+    ThriftServiceProcessor processor =
+        new ThriftServiceProcessor(new ThriftCodecManager(), emptyList(), scribe);
+    server = new ThriftServer(processor, config.forThriftServer()).start();
+  }
+
+  @Override
+  public void close() {
+    server.close();
+  }
+}

--- a/zipkin-transports/scribe/src/test/java/zipkin/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-transports/scribe/src/test/java/zipkin/scribe/ScribeSpanConsumerTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.scribe;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Annotation;
+import zipkin.AsyncSpanConsumer;
+import zipkin.BinaryAnnotation;
+import zipkin.BinaryAnnotation.Type;
+import zipkin.Codec;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.scribe.Scribe.LogEntry;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.isA;
+
+public class ScribeSpanConsumerTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  List<Span> consumed = new ArrayList<>();
+  AsyncSpanConsumer consumer = (input, callback) -> {
+    callback.onSuccess(null);
+    input.forEach(consumed::add);
+  };
+
+  Span span = new Span.Builder().traceId(1L).id(1L).name("foo").build();
+  String encodedSpan = new String(Base64.getEncoder().encode(Codec.THRIFT.writeSpan(span)), UTF_8);
+
+  @Test
+  public void entriesWithSpansAreConsumed() throws Exception {
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, "zipkin");
+
+    LogEntry entry = new LogEntry();
+    entry.category = "zipkin";
+    entry.message = encodedSpan;
+
+    assertThat(scribe.log(asList(entry)).get())
+        .isEqualTo(Scribe.ResultCode.OK);
+
+    assertThat(consumed)
+        .containsExactly(span);
+  }
+
+  @Test
+  public void entriesWithoutSpansAreSkipped() throws Exception {
+    AsyncSpanConsumer consumer = (input, callback) -> {
+      throw new AssertionError(); // as we shouldn't get here.
+    };
+
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, "zipkin");
+
+    LogEntry entry = new LogEntry();
+    entry.category = "notzipkin";
+    entry.message = "hello world";
+
+    scribe.log(asList(entry)).get();
+  }
+
+  @Test
+  public void malformedDataSetsFutureException() throws Exception {
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, "zipkin");
+
+    LogEntry entry = new LogEntry();
+    entry.category = "zipkin";
+    entry.message = "notbase64";
+
+    thrown.expect(ExecutionException.class); // from dereferenced future
+    thrown.expectCause(isA(IllegalArgumentException.class));
+
+    scribe.log(asList(entry)).get();
+  }
+
+  @Test
+  public void consumerExceptionBeforeCallbackSetsFutureException() throws Exception {
+    consumer = (input, callback) -> {
+      throw new NullPointerException();
+    };
+
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, "zipkin");
+
+    LogEntry entry = new LogEntry();
+    entry.category = "zipkin";
+    entry.message = encodedSpan;
+
+    thrown.expect(ExecutionException.class); // from dereferenced future
+    thrown.expectCause(isA(NullPointerException.class));
+
+    scribe.log(asList(entry)).get();
+  }
+
+  @Test
+  public void callbackExceptionSetsFutureException() throws Exception {
+    consumer = (input, callback) -> {
+      callback.onError(new NullPointerException());
+    };
+
+    ScribeSpanConsumer scribe = new ScribeSpanConsumer(consumer, "zipkin");
+
+    LogEntry entry = new LogEntry();
+    entry.category = "zipkin";
+    entry.message = encodedSpan;
+
+    thrown.expect(ExecutionException.class); // from dereferenced future
+    thrown.expectCause(isA(NullPointerException.class));
+
+    scribe.log(asList(entry)).get();
+  }
+
+  /** Finagle's zipkin tracer breaks on a column width with a trailing newline */
+  @Test
+  public void decodesSpanGeneratedByFinagle() throws Exception {
+    LogEntry entry = new LogEntry();
+    entry.category = "zipkin";
+    entry.message =
+        "CgABq/sBMnzE048LAAMAAAAOZ2V0VHJhY2VzQnlJZHMKAATN0p+4EGfTdAoABav7ATJ8xNOPDwAGDAAAAAQKAAEABR/wq+2DeAsAAgAAAAJzcgwAAwgAAX8AAAEGAAIkwwsAAwAAAAx6aXBraW4tcXVlcnkAAAoAAQAFH/Cr7zj4CwACAAAIAGFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh\n"
+            + "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAACgABAAUf8KwLPyILAAIAAABOR2MoOSwwLlBTU2NhdmVuZ2UsMjAxNS0wOS0xNyAxMjozNzowMiArMDAwMCwzMDQubWlsbGlzZWNvbmRzKzc2Mi5taWNyb3NlY29uZHMpDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAIAAQABKZ6AAoAAQAFH/CsDLfACwACAAAAAnNzDAADCAABfwAAAQYAAiTDCwADAAAADHppcGtpbi1xdWVyeQAADwAIDAAAAAULAAEAAAATc3J2L2ZpbmFnbGUudmVyc2lvbgsAAgAAAAY2LjI4LjAIAAMAAAAGDAAECAABfwAAAQYAAgAACwADAAAADHppcGtpbi1xdWVyeQAACwABAAAAD3Nydi9tdXgvZW5hYmxlZAsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAIAAAsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAJzYQsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAIkwwsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAJjYQsAAgAAAAEBCAADAAAAAAwABAgAAX8AAAEGAAL5YAsAAwAAAAx6aXBraW4tcXVlcnkAAAsAAQAAAAZudW1JZHMLAAIAAAAEAAAAAQgAAwAAAAMMAAQIAAF/AAABBgACJMMLAAMAAAAMemlwa2luLXF1ZXJ5AAACAAkAAA==\n";
+
+    new ScribeSpanConsumer(consumer, entry.category).log(asList(entry)).get();
+
+    char[] as = new char[2048];
+    Arrays.fill(as, 'a');
+    String reallyLongAnnotation = new String(as);
+
+    Endpoint zipkinQuery = Endpoint.create("zipkin-query", (127 << 24) | 1, 9411);
+    Endpoint zipkinQuery0 = Endpoint.create("zipkin-query", (127 << 24) | 1);
+
+    assertThat(consumed).containsExactly(
+        new Span.Builder()
+            .traceId(-6054243957716233329L)
+            .name("getTracesByIds")
+            .id(-3615651937927048332L)
+            .parentId(-6054243957716233329L)
+            .addAnnotation(Annotation.create(1442493420635000L, Constants.SERVER_RECV, zipkinQuery))
+            .addAnnotation(Annotation.create(1442493420747000L, reallyLongAnnotation, zipkinQuery))
+            .addAnnotation(Annotation.create(1442493422583586L,
+                "Gc(9,0.PSScavenge,2015-09-17 12:37:02 +0000,304.milliseconds+762.microseconds)",
+                zipkinQuery))
+            .addAnnotation(Annotation.create(1442493422680000L, Constants.SERVER_SEND, zipkinQuery))
+            .addBinaryAnnotation(
+                BinaryAnnotation.create("srv/finagle.version", "6.28.0", zipkinQuery0))
+            .addBinaryAnnotation(binaryAnnotation("srv/mux/enabled", true, zipkinQuery0))
+            .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, zipkinQuery))
+            .addBinaryAnnotation(BinaryAnnotation.address(Constants.CLIENT_ADDR,
+                Endpoint.create("zipkin-query", (127 << 24) | 1, 63840)))
+            .addBinaryAnnotation(binaryAnnotation("numIds", 1, zipkinQuery))
+            .debug(false)
+            .build());
+  }
+
+  static BinaryAnnotation binaryAnnotation(String key, boolean value, Endpoint endpoint) {
+    return BinaryAnnotation.create(key, value ? new byte[] {1} : new byte[] {0}, Type.BOOL,
+        endpoint);
+  }
+
+  static BinaryAnnotation binaryAnnotation(String key, int value, Endpoint endpoint) {
+    byte[] bytes = new byte[] {
+        (byte) (value >>> 24),
+        (byte) (value >>> 16),
+        (byte) (value >>> 8),
+        (byte) value};
+    return BinaryAnnotation.create(key, bytes, Type.I32, endpoint);
+  }
+}


### PR DESCRIPTION
This re-adds the Scribe transport, formerly removed in #30. Scribe is
enabled by default in the exec jar (used in docker).

Custom builds can enable Scribe by including the `transport-scribe`
dependency. Further options may become available dependeding on the
outcome of our modularity discussion (#108).

This component honors the only relevant environment variable from
zipkin-scala: `ZIPKIN_COLLECTOR_PORT`. This sets the scribe listen port,
defaulting to port 9410.

Fixes #150