### PR TITLE
Adds SpanConsumerLogger to make logging consistent across transports

### DIFF
--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/SpansDecoder.java
@@ -15,17 +15,17 @@ package zipkin.kafka;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 import kafka.serializer.Decoder;
 import zipkin.Codec;
 import zipkin.Span;
+import zipkin.internal.SpanConsumerLogger;
 
 /**
  * Conditionally decodes depending on whether the input bytes are encoded as a single span or a
  * list. Malformed input is ignored.
  */
 final class SpansDecoder implements Decoder<List<Span>> {
-  final Logger logger = Logger.getLogger(SpansDecoder.class.getName());
+  final SpanConsumerLogger logger = new SpanConsumerLogger(KafkaStreamProcessor.class);
 
   @Override
   public List<Span> fromBytes(byte[] bytes) {
@@ -47,7 +47,7 @@ final class SpansDecoder implements Decoder<List<Span>> {
         return Collections.singletonList(Codec.THRIFT.readSpan(bytes));
       }
     } catch (RuntimeException e) {
-      logger.fine("malformed message: " + e.getMessage());
+      logger.errorDecoding(e);
       return Collections.emptyList();
     }
   }

--- a/zipkin/src/main/java/zipkin/internal/SpanConsumerLogger.java
+++ b/zipkin/src/main/java/zipkin/internal/SpanConsumerLogger.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Logger;
+import zipkin.Callback;
+import zipkin.Span;
+
+import static java.lang.String.format;
+import static java.util.logging.Level.WARNING;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * Common logging patterns for span consumption lead to a consistent troubleshooting experience,
+ * despite transport diversity.
+ */
+// internal until drift stops
+public final class SpanConsumerLogger {
+  private final Logger logger;
+
+  public SpanConsumerLogger(Class<?> clazz) {
+    this.logger = Logger.getLogger(checkNotNull(clazz, "class").getName());
+  }
+
+  public SpanConsumerLogger(Logger logger) {
+    this.logger = checkNotNull(logger, "logger");
+  }
+
+  public String errorDecoding(Throwable e) {
+    return error("Cannot decode spans", e);
+  }
+
+  /**
+   * When storing spans, an exception can be raised before or after the fact. This adds context of
+   * span ids to give logs more relevance.
+   */
+  public String errorAcceptingSpans(List<Span> spans, Throwable e) {
+    // The exception could be related to a span being huge. Instead of filling logs,
+    // print trace id, span id pairs
+    StringBuilder msg = appendSpanIds(spans, new StringBuilder("Cannot accept traceId -> spanId "));
+    return error(msg.toString(), e);
+  }
+
+  public Callback<Void> acceptSpansCallback(final List<Span> spans) {
+    return new Callback<Void>() {
+      @Override public void onSuccess(@Nullable Void value) {
+      }
+
+      @Override public void onError(Throwable t) {
+        errorAcceptingSpans(spans, t);
+      }
+
+      @Override
+      public String toString() {
+        return appendSpanIds(spans, new StringBuilder("AcceptSpans(")).append(")").toString();
+      }
+    };
+  }
+
+  public String error(String message, Throwable e) {
+    message = format("%s due to %s(%s)", message, e.getClass().getSimpleName(),
+        e.getMessage() == null ? "" : e.getMessage());
+    logger.log(WARNING, message, e);
+    return message;
+  }
+
+  static StringBuilder appendSpanIds(List<Span> spans, StringBuilder message) {
+    message.append("[");
+    for (Iterator<Span> iterator = spans.iterator(); iterator.hasNext(); ) {
+      Span span = iterator.next();
+      message.append(format("%016x", span.traceId)).append(" -> ").append(format("%016x", span.id));
+      if (iterator.hasNext()) message.append(", ");
+    }
+    return message.append("]");
+  }
+}

--- a/zipkin/src/test/java/zipkin/internal/SpanConsumerLoggerTest.java
+++ b/zipkin/src/test/java/zipkin/internal/SpanConsumerLoggerTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Test;
+import zipkin.Callback;
+import zipkin.Span;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpanConsumerLoggerTest {
+  List<String> messages = new ArrayList<>();
+
+  SpanConsumerLogger logger = new SpanConsumerLogger(new Logger("", null) {
+    @Override
+    public void log(Level level, String msg, Throwable thrown) {
+      assertThat(level).isEqualTo(Level.WARNING);
+      messages.add(msg);
+    }
+  });
+
+  Span span1 = new Span.Builder().traceId(1L).id(1L).name("foo").build();
+  Span span2 = new Span.Builder().traceId(1L).parentId(1L).id(2L).name("bar").build();
+
+  @Test
+  public void acceptSpansCallback_toStringIncludesSpanIds() {
+    assertThat(logger.acceptSpansCallback(asList(span1, span2)))
+        .hasToString(
+            "AcceptSpans([0000000000000001 -> 0000000000000001, 0000000000000001 -> 0000000000000002])");
+  }
+
+  @Test
+  public void acceptSpansCallback_onErrorWithNullMessage() {
+    Callback<Void> callback = logger.acceptSpansCallback(asList(span1));
+    callback.onError(new RuntimeException());
+
+    assertThat(messages)
+        .containsExactly(
+            "Cannot accept traceId -> spanId [0000000000000001 -> 0000000000000001] due to RuntimeException()");
+  }
+
+  @Test
+  public void acceptSpansCallback_onErrorWithMessage() {
+    Callback<Void> callback = logger.acceptSpansCallback(asList(span1));
+    callback.onError(new IllegalArgumentException("no beer"));
+
+    assertThat(messages)
+        .containsExactly(
+            "Cannot accept traceId -> spanId [0000000000000001 -> 0000000000000001] due to IllegalArgumentException(no beer)");
+  }
+
+  @Test
+  public void errorAcceptingSpans_onErrorWithNullMessage() {
+    String message = logger.errorAcceptingSpans(asList(span1), new RuntimeException());
+
+    assertThat(messages)
+        .containsExactly(message)
+        .containsExactly(
+            "Cannot accept traceId -> spanId [0000000000000001 -> 0000000000000001] due to RuntimeException()");
+  }
+
+  @Test
+  public void errorAcceptingSpans_onErrorWithMessage() {
+    String message =
+        logger.errorAcceptingSpans(asList(span1), new IllegalArgumentException("no beer"));
+
+    assertThat(messages)
+        .containsExactly(message)
+        .containsExactly(
+            "Cannot accept traceId -> spanId [0000000000000001 -> 0000000000000001] due to IllegalArgumentException(no beer)");
+  }
+
+  @Test
+  public void errorDecoding_onErrorWithNullMessage() {
+    String message = logger.errorDecoding(new RuntimeException());
+
+    assertThat(messages)
+        .containsExactly(message)
+        .containsExactly("Cannot decode spans due to RuntimeException()");
+  }
+
+  @Test
+  public void errorDecoding_onErrorWithMessage() {
+    String message =
+        logger.errorDecoding(new IllegalArgumentException("no beer"));
+
+    assertThat(messages)
+        .containsExactly(message)
+        .containsExactly("Cannot decode spans due to IllegalArgumentException(no beer)");
+  }
+}


### PR DESCRIPTION
Common logging patterns for span consumption lead to a consistent
troubleshooting experience, despite transport diversity.

Ex.
```bash
$ curl -X POST -s localhost:9411/api/v1/spans -d 'asdsadas'
Cannot decode spans due to IllegalArgumentException(Malformed reading List<Span> from json: asdsadas=)
```