### PR TITLE
Excludes airlift:configuration dependency to avoid classpath clash

### DIFF
--- a/zipkin-transports/scribe/pom.xml
+++ b/zipkin-transports/scribe/pom.xml
@@ -46,6 +46,13 @@
       <groupId>com.facebook.swift</groupId>
       <artifactId>swift-service</artifactId>
       <version>${swift.version}</version>
+      <exclusions>
+        <!-- airlift:configuration includes bval-jsr303, which can easily conflict -->
+        <exclusion>
+          <groupId>io.airlift</groupId>
+          <artifactId>configuration</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The Scribe transport's FB Swift (Thrift RPC) dependendency included
jsr303 which conflicts with Spring, causing the server to crash at
bootstrap. This was implicit via an unused implicit dependency,
airlift:configuration, which is now excluded.

Note this failure was only possible to see, if the exec jar was unpacked
and run via `java  -cp '.:lib/*' zipkin.server.ZipkinServer`.

Here's the exception encountered:

```
query_1 | Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mysql.CONFIGURATION_PROPERTIES': Initialization of bean failed; nested exception is java.lang.AbstractMethodError: org.apache.bval.jsr303.ConfigurationImpl.getDefaultParameterNameProvider()Ljavax/validation/ParameterNameProvider;
query_1 | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:553) ~[spring-beans-4.2.5.RELEASE.jar:4.2.5.RELEASE]
```