### PR TITLE
Makes empty spans cheaper to create

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,7 @@ Zipkin Benchmarks
 This module includes [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmarks for Zipkin.
 
 === Running the benchmark
-From the parent directory, run `mvn install` to build the benchmarks, and the following to run them:
+From the parent directory, run `./mvnw install` to build the benchmarks, and the following to run them:
 
 ```bash
 # Run with a single worker thread

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <jmh.version>1.11.3</jmh.version>
+    <jmh.version>1.12</jmh.version>
   </properties>
 
   <dependencies>

--- a/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class SpanBenchmarks {
+
+  @Benchmark
+  public Span buildMinimalSpan() {
+    return new Span.Builder().traceId(1L).id(1L).name("").build();
+  }
+
+  @Benchmark
+  public Span buildMinimalClientSpan() {
+    Endpoint client = Endpoint.create("", 172 << 24 | 17 << 16 | 3);
+    return new Span.Builder()
+        .traceId(1L)
+        .name("")
+        .id(1L)
+        .timestamp(1444438900948000L)
+        .duration(31000L)
+        .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, client))
+        .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, client))
+        .build();
+  }
+
+  @Benchmark
+  public Span buildRPCSpan() {
+    Endpoint web = Endpoint.create("web", 172 << 24 | 17 << 16 | 3, 8080);
+    Endpoint query = Endpoint.create("query", 172 << 24 | 17 << 16 | 3, 9411);
+    return new Span.Builder() // web calls query
+        .traceId(1L)
+        .name("get")
+        .id(2L)
+        .parentId(1L)
+        .timestamp(1444438900941000L)
+        .duration(77000L)
+        .addAnnotation(Annotation.create(1444438900941000L, Constants.CLIENT_SEND, web))
+        .addAnnotation(Annotation.create(1444438900947000L, Constants.SERVER_RECV, query))
+        .addAnnotation(Annotation.create(1444438901017000L, Constants.SERVER_SEND, query))
+        .addAnnotation(Annotation.create(1444438901018000L, Constants.CLIENT_RECV, web))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, query))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.CLIENT_ADDR, web))
+        .build();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + SpanBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -14,6 +14,7 @@
 package zipkin;
 
 import java.net.InetSocketAddress;
+import java.util.Locale;
 import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 import zipkin.internal.Util;
@@ -75,7 +76,8 @@ public final class Endpoint {
   public final Short port;
 
   Endpoint(String serviceName, int ipv4, Short port) {
-    this.serviceName = checkNotNull(serviceName, "serviceName").toLowerCase();
+    this.serviceName = checkNotNull(serviceName, "serviceName").isEmpty() ? ""
+        : serviceName.toLowerCase(Locale.ROOT);
     this.ipv4 = ipv4;
     this.port = port;
   }

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -65,9 +65,13 @@ public final class Util {
     return reference;
   }
 
+  public static <T> List<T> list(@Nullable Collection<T> input) {
+    if (input == null || input.isEmpty()) return Collections.emptyList();
+    return Collections.unmodifiableList(new ArrayList<>(input));
+  }
+
   public static <T extends Comparable<? super T>> List<T> sortedList(@Nullable Collection<T> input) {
     if (input == null || input.isEmpty()) return Collections.emptyList();
-    if (input.size() == 1) return Collections.singletonList(input.iterator().next());
     List<T> result = new ArrayList<>(input);
     Collections.sort(result);
     return Collections.unmodifiableList(result);


### PR DESCRIPTION
I noticed another test was making my CPU fan go on. Turns out we are
needlessly doing work on sparse spans.

Here are the before and after from my laptop:

```
SpanBenchmarks.buildMinimalClientSpan  thrpt   15   7.440 ± 0.418  ops/us
SpanBenchmarks.buildMinimalSpan        thrpt   15  16.224 ± 1.089  ops/us
SpanBenchmarks.buildRPCSpan            thrpt   15   3.249 ± 0.270  ops/us

SpanBenchmarks.buildMinimalClientSpan  thrpt   15   12.384 ± 0.193  ops/us
SpanBenchmarks.buildMinimalSpan        thrpt   15  128.275 ± 1.363  ops/us
SpanBenchmarks.buildRPCSpan            thrpt   15    3.624 ± 0.209  ops/us
```