### PR TITLE
Teaches Sampler to test spans and adds ZooKeeper support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <module>zipkin-junit</module>
     <module>benchmarks</module>
     <module>interop</module>
+    <module>zipkin-samplers</module>
     <module>zipkin-storage</module>
     <module>zipkin-transports</module>
     <module>zipkin-server</module>
@@ -147,6 +148,12 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>centralsync-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>sampler-zookeeper</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/zipkin-samplers/pom.xml
+++ b/zipkin-samplers/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.12.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-samplers</artifactId>
+  <name>Samplers</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>zookeeper</module>
+  </modules>
+</project>

--- a/zipkin-samplers/zookeeper/README.md
+++ b/zipkin-samplers/zookeeper/README.md
@@ -1,0 +1,11 @@
+# sampler-zookeeper
+This is an adaptive sampler which can help prevent a surge in traffic
+from overwhelming the zipkin storage layer.
+
+This works in scenarios where you can coordinate the collection/ingestion
+tier and are running zookeeper.
+
+`zipkin.sampler.zookeeper.ZooKeeperSampler.Builder` includes defaults
+that will against local Zookeeper.
+
+The sampling implementation is compatible with [zipkin-scala](https://github.com/openzipkin/zipkin/tree/master/zipkin-sampler).

--- a/zipkin-samplers/zookeeper/pom.xml
+++ b/zipkin-samplers/zookeeper/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.java</groupId>
+    <artifactId>zipkin-samplers</artifactId>
+    <version>0.12.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>sampler-zookeeper</artifactId>
+  <name>Sampler: ZooKeeper</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <curator.version>2.10.0</curator.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>twttr</id>
+      <url>https://maven.twttr.com/</url>
+      <name>Needed while io.zipkin:zipkin-sampler depends on old ZooKeeper Client</name>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <!-- for com.twitter.zipkin.sampler.AdaptiveSampleRate -->
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-sampler</artifactId>
+      <version>1.39.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import com.twitter.zipkin.sampler.AdaptiveSampleRate;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import zipkin.Sampler;
+import zipkin.Span;
+
+import static zipkin.internal.Util.checkArgument;
+import static zipkin.internal.Util.checkNotNull;
+
+public final class ZooKeeperSampler extends Sampler implements AutoCloseable {
+
+  /** Configuration including defaults needed to consume spans from a Kafka basePath. */
+  public static final class Builder {
+    float initialRate = 1.0f;
+    String basePath = "/zipkin/sampler/";
+    String zookeeper = "localhost:2181";
+    int updateFrequency = 30;
+    int windowSize = 30 * 60;
+    int sufficientWindowSize = 10 * 60;
+    int outlierThreshold = 5 * 60;
+
+    /** Rate used until an adaptive one calculated. 0.0001 means 0.01% of traces. Defaults to 1.0 */
+    public Builder initialRate(float rate) {
+      checkArgument(rate >= 0 && rate <= 1, "rate should be between 0 and 1: was %s", rate);
+      this.initialRate = rate;
+      return this;
+    }
+
+    /** Base path in ZooKeeper for the sampler to use. Defaults to "zipkin" */
+    public Builder basePath(String basePath) {
+      this.basePath = checkNotNull(basePath, "basePath");
+      return this;
+    }
+
+    /** The zookeeper connect string, Defaults to 127.0.0.1:2181 */
+    public Builder zookeeper(String zookeeper) {
+      this.zookeeper = checkNotNull(zookeeper, "zookeeper");
+      return this;
+    }
+
+    /** Frequency in seconds which to update the sample rate. Defaults to 30 */
+    public Builder updateFrequency(int updateFrequency) {
+      checkArgument(updateFrequency >= 1, "updateFrequency must be at least 1 second");
+      this.updateFrequency = updateFrequency;
+      return this;
+    }
+
+    /** Seconds of request rate data to base sample rate on. Defaults to 1800 (30 minutes) */
+    public Builder windowSize(int windowSize) {
+      this.windowSize = windowSize;
+      return this;
+    }
+
+    /**
+     * Seconds of request rate data to gather before calculating sample rate. Defaults to 600 (10
+     * minutes)
+     */
+    public Builder sufficientWindowSize(int sufficientWindowSize) {
+      this.sufficientWindowSize = sufficientWindowSize;
+      return this;
+    }
+
+    /** Seconds to see outliers before updating sample rate. Defaults to 300 (5 minutes) */
+    public Builder outlierThreshold(int outlierThreshold) {
+      this.outlierThreshold = outlierThreshold;
+      return this;
+    }
+
+    public ZooKeeperSampler build() {
+      return new ZooKeeperSampler(this);
+    }
+  }
+
+  final AtomicLong boundary;
+  final AtomicInteger spanCount;
+  final AdaptiveSampleRate sampleRate;
+
+  ZooKeeperSampler(Builder builder) {
+    this.boundary = new AtomicLong((long) (Long.MAX_VALUE * builder.initialRate)); // safe cast as less <= 1
+    this.spanCount = new AtomicInteger();
+    this.sampleRate = new AdaptiveSampleRate(
+        boundary,
+        spanCount,
+        builder.zookeeper,
+        Collections.emptyMap(),
+        builder.basePath,
+        builder.updateFrequency,
+        builder.windowSize,
+        builder.sufficientWindowSize,
+        builder.outlierThreshold
+    );
+  }
+
+  @Override
+  public void close() {
+    this.sampleRate.close();
+  }
+
+  @Override public boolean isSampled(Span span) {
+    boolean result = super.isSampled(span);
+    if (result) spanCount.incrementAndGet();
+    return result;
+  }
+
+  @Override protected long boundary() {
+    return boundary.get();
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperSamplerTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperSamplerTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.InMemoryStorage;
+import zipkin.Span;
+import zipkin.internal.CallbackCaptor;
+
+import static java.util.Arrays.asList;
+import static org.apache.curator.framework.CuratorFrameworkFactory.newClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+public class ZooKeeperSamplerTest {
+  InMemoryStorage storage = new InMemoryStorage();
+
+  @Test public void sampleRateReadFromZookeeper() throws Exception {
+    // Simulates an existing sample rate, set from zookeeper
+    client.setData().forPath("/sampleRate", "0.9".getBytes());
+
+    accept(spans);
+
+    assertThat(storage.acceptedSpanCount())
+        .isCloseTo((int) (spans.length * 0.9), withinPercentage(3));
+  }
+
+  @Test public void ignoresBadRateReadFromZookeeper() throws Exception {
+    // Simulates a bad rate, set from zookeeper
+    client.setData().forPath("/sampleRate", "1.9".getBytes());
+
+    accept(spans);
+
+    assertThat(storage.acceptedSpanCount())
+        .isEqualTo(spans.length); // default is retain all
+  }
+
+  @Test public void exportsStoreRateToZookeeperOnInterval() throws Exception {
+    accept(spans);
+
+    // Until the update interval, we'll see a store rate of zero
+    assertThat(getLocalStoreRate()).isZero();
+
+    // Await until update interval passes (1 second + fudge)
+    Thread.sleep(1000); // let the update interval pass
+
+    // since update frequency is secondly, the rate exported to ZK will be the amount stored * 60
+    assertThat(getLocalStoreRate())
+        .isEqualTo(spans.length * 60);
+  }
+
+  @Before public void clear() throws Exception {
+    // default to always sample
+    client.setData().forPath("/sampleRate", "1.0".getBytes());
+
+    // remove any storage rate members
+    List<String> groupMembers = client.getChildren().forPath("/storeRates");
+    if (!groupMembers.isEmpty()) {
+      client.setData().forPath("/storeRates/" + groupMembers.get(0), new byte[] {'0'});
+    }
+  }
+
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large input to avoid
+   * flaking out due to PRNG nuance.
+   */
+  static Span[] spans = new Random().longs(100000).mapToObj(t -> span(t)).toArray(Span[]::new);
+
+  static Span span(long traceId) {
+    Endpoint e = Endpoint.create("service", 127 << 24 | 1, 8080);
+    Annotation ann = Annotation.create(System.currentTimeMillis() * 1000, Constants.SERVER_RECV, e);
+    return new Span.Builder().traceId(traceId).id(traceId).name("get").addAnnotation(ann).build();
+  }
+
+  static CuratorFramework client;
+  static TestingServer zookeeper;
+  static ZooKeeperSampler sampler;
+
+  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
+  void accept(Span... spans) {
+    CallbackCaptor<Void> captor = new CallbackCaptor<>();
+    storage.asyncSpanConsumer(sampler).accept(asList(spans), captor);
+    captor.get(); // block on result
+  }
+
+  @BeforeClass public static void beforeAll() throws Exception {
+    zookeeper = new TestingServer();
+    client = newClient(zookeeper.getConnectString(), new RetryOneTime(200 /* ms */));
+    zookeeper.start();
+    client.start();
+    // ZooKeeperSampler doesn't create these!
+    client.createContainers("/election");
+    client.createContainers("/storeRates");
+    client.createContainers("/sampleRate");
+    client.createContainers("/targetStoreRate");
+
+    sampler = new ZooKeeperSampler.Builder()
+        .zookeeper(zookeeper.getConnectString())
+        .basePath("") // shorten for test readability
+        .updateFrequency(1) // least possible value
+        .build();
+
+    // prime zookeeper data, to make sure connection-concerns don't fail tests
+    sampler.isSampled(spans[0]);
+    Thread.sleep(1000); // let the update interval pass
+  }
+
+  @AfterClass public static void afterAll() throws IOException {
+    client.close();
+    zookeeper.close();
+    sampler.close();
+  }
+
+  /** Twitter's zookeeper group is where you store the same value as a child node */
+  static int getLocalStoreRate() throws Exception {
+    String groupMember = client.getChildren().forPath("/storeRates").get(0);
+    byte[] data = client.getData().forPath("/storeRates/" + groupMember);
+    return data.length == 0 ? 0 : Integer.parseInt(new String(data));
+  }
+}
+
+

--- a/zipkin/src/main/java/zipkin/InternalSamplingAsyncSpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/InternalSamplingAsyncSpanConsumer.java
@@ -31,7 +31,7 @@ final class InternalSamplingAsyncSpanConsumer implements AsyncSpanConsumer {
   public void accept(List<Span> input, Callback<Void> callback) {
     List<Span> sampled = new ArrayList<>(input.size());
     for (Span s : input) {
-      if ((s.debug != null && s.debug) || sampler.isSampled(s.traceId)) sampled.add(s);
+      if (sampler.isSampled(s)) sampled.add(s);
     }
     asyncConsumer.accept(sampled, callback);
   }

--- a/zipkin/src/main/java/zipkin/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin/StorageComponent.java
@@ -30,8 +30,7 @@ public interface StorageComponent extends AutoCloseable {
 
   /**
    * Used to store spans received on a transport such as Kafka. The provided consumer will retain
-   * spans according to the sampler's policy with one notable exception: {@link Span#debug Debug}
-   * traces are always stored.
+   * spans according to the sampler's policy.
    */
   AsyncSpanConsumer asyncSpanConsumer(Sampler sampler);
 


### PR DESCRIPTION
In practice, there are two purposes for sampler: instrumentation and
storage. This change allows a sampler to be used for both purposes.

It also makes the sampler extensible, so that the rate can be dynamic.
With this feature, it is possible to implement adaptive sampling via
ZooKeeper.

Part one of #164
Part two is rewriting out scala + twitter-util + flakey repository (likely with Curator)