### PR TITLE
Rewrites ZooKeeperSampler to eliminate Scala dependency

### DIFF
--- a/zipkin-samplers/zookeeper/README.md
+++ b/zipkin-samplers/zookeeper/README.md
@@ -2,10 +2,50 @@
 This is an adaptive sampler which can help prevent a surge in traffic
 from overwhelming the zipkin storage layer.
 
-This works in scenarios where you can coordinate the collection/ingestion
-tier and are running zookeeper.
+This works in scenarios where you can coordinate the collection tier
+with ZooKeeper 3.4.x or ZooKeeper 3.5.x.
 
 `zipkin.sampler.zookeeper.ZooKeeperSampler.Builder` includes defaults
-that will against local Zookeeper.
+that will against a given [Curator](http://curator.apache.org) client.
 
-The sampling implementation is compatible with [zipkin-scala](https://github.com/openzipkin/zipkin/tree/master/zipkin-sampler).
+Example:
+
+```java
+// The ZooKeeperSampler requires you to supply your own Curator.
+client = CuratorFrameworkFactory.builder()
+    .connectString(zookeeperConnect)
+    .retryPolicy(new RetryOneTime(1))
+    .build();
+client.start();
+client.blockUntilConnected(3, TimeUnit.SECONDS);
+
+// This will sample spans based on the capacity of the storage layer.
+// Capacity is spans/minute and set by an admin.
+sampler = new ZooKeeperSampler.Builder()
+    .id("kafka-" + topic + "@" + hostAndPort)
+    .build(client);
+
+// Initialize a collector that will sample incoming spans based on
+// a coordinated rate.
+collector = new KafkaCollector.Builder()
+    .zookeeper(zookeeperConnect)
+    .topic(topic)
+    .writeTo(storage, sampler);
+```
+
+## ZooKeeper Paths
+
+The following paths are relative to `zipkin.sampler.zookeeper.ZooKeeperSampler.basePath`,
+which defaults to "/zipkin/sampler". 
+
+Path | Owner | Description
+--- | --- | ---
+/targetStoreRate | admin | Admin changes this to no more than 95% capacity of the storage layer in spans/minute.
+/sampleRate | leader | Each member of the sample group's `isSampled(Span)` method will pass based on this value. This is updated no more than {sampler.updateInterval} by the leader.
+/storeRates/{sampler.id} | each sampler | Updated per {sampler.updateInterval} to the amount of spans sampled per minute.
+/election | each sampler | This path is used to determine or elect a new leader.
+
+## More information
+More details are available in the [javadoc](./src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java)
+The sampling implementation was initially based on [zipkin-scala](https://github.com/openzipkin/zipkin/tree/1.39.6/zipkin-sampler).
+

--- a/zipkin-samplers/zookeeper/pom.xml
+++ b/zipkin-samplers/zookeeper/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -31,54 +33,35 @@
     <curator.version>2.10.0</curator.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>twttr</id>
-      <url>https://maven.twttr.com/</url>
-      <name>Needed while io.zipkin:zipkin-sampler depends on old ZooKeeper Client</name>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin</artifactId>
     </dependency>
 
-    <!-- for com.twitter.zipkin.sampler.AdaptiveSampleRate -->
-    <dependency>
-      <groupId>io.zipkin</groupId>
-      <artifactId>zipkin-sampler</artifactId>
-      <version>1.39.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>log4j-over-slf4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <version>${curator.version}</version>
-      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>${curator.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculator.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculator.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This calculates a new sample rate given the input measurements or returns empty if the current
+ * rate is fine.
+ *
+ * <p>The sample rate is calculated using a discounted average. The discount rate is low (0.09),
+ * which prefers larger numbers. This is used to ensure large measurements (like a traffic spike)
+ * trip a lower sample rate, while small measurements (like a new collector instance) don't.
+ */
+final class SampleRateCalculator implements Function<Optional<List<Integer>>, Optional<Float>> {
+  final Logger log = LoggerFactory.getLogger(SampleRateCalculator.class);
+
+  private final AtomicInteger target;
+  private final AtomicReference<Float> sampleRate;
+  private final float discountRate = 0.09f;
+  private final float threshold = 0.05f;
+
+  SampleRateCalculator(AtomicInteger target, AtomicReference<Float> sampleRate) {
+    this.target = target;
+    this.sampleRate = sampleRate;
+  }
+
+  @Override public Optional<Float> apply(Optional<List<Integer>> input) {
+    if (!input.isPresent()) return Optional.empty();
+    List<Integer> measurements = input.get();
+    int discountedAverage = discountedAverage(measurements, discountRate);
+    log.debug("{} discounted average measurement: {}", discountRate, discountedAverage);
+    if (discountedAverage <= 0) return Optional.empty();
+
+    float oldSampleRate = sampleRate.get();
+    float newSampleRate = Math.min(1.0f, oldSampleRate * target.get() / discountedAverage);
+
+    float change = Math.abs(oldSampleRate - newSampleRate) / oldSampleRate;
+    if (change > 0.0f) {
+      log.debug("Sample rate changed {} from {} to {}", change, oldSampleRate, sampleRate);
+      if (change < threshold) {
+        log.debug("Sample rate change was less than {} threshold. Ignoring", threshold);
+      }
+    }
+    return change >= threshold ? Optional.of(newSampleRate) : Optional.empty();
+  }
+
+  static int discountedAverage(List<Integer> measurements, float discountRate) {
+    double discountTotal = 0;
+    double discountedVals = 0;
+    for (int i = 0; i < measurements.size(); i++) {
+      double discount = Math.pow(discountRate, i);
+      discountTotal += discount;
+      discountedVals += discount * measurements.get(i);
+    }
+    return (int) (discountedVals / discountTotal);
+  }
+}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculatorInput.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculatorInput.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Takes measurements by name and returns a summarized list, or empty. Empty is returned until
+ * measurements are notable enough to warrant recalculating a sample rate.
+ */
+final class SampleRateCalculatorInput
+    implements Function<Map<String, Integer>, Optional<List<Integer>>> {
+  final Logger log = LoggerFactory.getLogger(SampleRateCalculatorInput.class);
+
+  final AtomicInteger target; // visible for testing
+  private final int measurementsInWindow;
+  private final int sufficientThreshold;
+  private final int requiredOutliers;
+  private final ArrayDeque<Map<String, Integer>> buffer;
+
+  SampleRateCalculatorInput(ZooKeeperSampler.Builder builder, AtomicInteger target) {
+    this.target = target;
+    this.measurementsInWindow = builder.windowSize / builder.updateFrequency;
+    this.sufficientThreshold = builder.sufficientWindowSize / builder.updateFrequency;
+    this.requiredOutliers = builder.outlierThreshold / builder.updateFrequency;
+    this.buffer = new ArrayDeque<>(measurementsInWindow);
+  }
+
+  @Override public Optional<List<Integer>> apply(Map<String, Integer> nextMeasurements) {
+    List<Integer> measurements = addMeasurementsAndSumValues(nextMeasurements);
+    boolean targetSet = target.get() > 0;
+    boolean sufficientMeasurementsInWindow = measurements.size() >= sufficientThreshold;
+    boolean allMeasurementsInWindowArePositive = measurements.stream().allMatch(j -> j > 0);
+    boolean lastMeasurementsWereOutliers = lastMeasurementsWereOutliers(measurements);
+    if (targetSet
+        && allMeasurementsInWindowArePositive
+        && sufficientMeasurementsInWindow
+        && lastMeasurementsWereOutliers) {
+      log.debug("summarized measurements in window warrant a new sample rate: {}", measurements);
+      return Optional.of(measurements);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns a list of aggregate rate measurements, in insertion order
+   */
+  private List<Integer> addMeasurementsAndSumValues(Map<String, Integer> nextMeasurements) {
+    synchronized (buffer) {
+      if (buffer.size() == measurementsInWindow) {
+        buffer.remove();
+      }
+      buffer.add(nextMeasurements);
+      log.debug("summarizing measurements in window: {}", buffer);
+      return buffer.stream()
+          .map(m -> m.values().stream().mapToInt(Integer::intValue).sum())
+          .collect(Collectors.toList());
+    }
+  }
+
+  /** The most recent data has to include only outliers to warrant a sample rate change. */
+  private boolean lastMeasurementsWereOutliers(List<Integer> measurements) {
+    // outliers have to be the most recent measurements
+    int i = Math.max(measurements.size() - requiredOutliers, 0);
+    int outliers = 0;
+    while (i < measurements.size() && isOutlier(measurements.get(i++))) {
+      outliers++;
+    }
+    return outliers == requiredOutliers;
+  }
+
+  /** An outlier is a measurement that is outside 15% of the target */
+  private boolean isOutlier(int measurement) {
+    int target = this.target.get();
+    return Math.abs(measurement - target) > target * 0.15;
+  }
+}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateListener.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateListener.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.internal.Util;
+
+/** Listens for changes in sample rate and updates boundary accordingly */
+final class SampleRateListener implements NodeCacheListener, Closeable {
+  final Logger log = LoggerFactory.getLogger(SampleRateListener.class);
+
+  final AtomicReference<Float> sampleRate;
+  final AtomicLong boundary;
+  final NodeCache cache;
+
+  SampleRateListener(CuratorFramework client, String sampleRatePath,
+      AtomicReference<Float> sampleRate, AtomicLong boundary) {
+    this.sampleRate = sampleRate;
+    this.boundary = boundary;
+    try {
+      client.checkExists().creatingParentContainersIfNeeded().forPath(sampleRatePath);
+    } catch (Exception e) {
+      throw new IllegalStateException("Error creating " + sampleRatePath, e);
+    }
+    this.cache = new NodeCache(client, sampleRatePath);
+    try {
+      this.cache.start();
+    } catch (Exception e) {
+      throw new IllegalStateException("Error starting cache for " + sampleRatePath, e);
+    }
+    this.cache.getListenable().addListener(this);
+  }
+
+  @Override public void nodeChanged() throws Exception {
+    byte[] bytes = cache.getCurrentData().getData();
+    if (bytes.length == 0) return;
+    Float newSampleRate;
+    try {
+      newSampleRate = Float.valueOf(new String(bytes, Util.UTF_8));
+    } catch (NumberFormatException e) {
+      log.warn("Error parsing sampleRate {}", e.getMessage());
+      return;
+    }
+    if (newSampleRate < 0.0f || newSampleRate > 1.0f) {
+      log.warn("sampleRate should be between 0 and 1: was {}", newSampleRate);
+    } else {
+      sampleRate.set(newSampleRate);
+      boundary.set((long) (Long.MAX_VALUE * newSampleRate));
+    }
+  }
+
+  @Override public void close() throws IOException {
+    cache.close();
+  }
+}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdateGuard.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdateGuard.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin.sampler.zookeeper.ZooKeeperSampler.Builder;
+
+/**
+ * Allows an update while a leader, but not more often than {@link Builder#updateFrequency(int)}
+ * seconds.
+ */
+final class SampleRateUpdateGuard implements Supplier<Boolean>, Closeable {
+  final Logger log = LoggerFactory.getLogger(SampleRateUpdateGuard.class);
+
+  final CuratorFramework client; // visible for testing
+  final LeaderLatch latch; // visible for testing
+  private final long updateFrequencyNanos;
+  private long nextRun = System.nanoTime(); // guarded by this
+
+  SampleRateUpdateGuard(CuratorFramework client, Builder builder) {
+    this.client = client;
+    this.updateFrequencyNanos = TimeUnit.SECONDS.toNanos(builder.updateFrequency);
+    String electionPath = builder.basePath + "/election";
+    try {
+      client.checkExists().creatingParentContainersIfNeeded().forPath(electionPath);
+    } catch (Exception e) {
+      throw new IllegalStateException("Error creating " + electionPath, e);
+    }
+    latch = new LeaderLatch(client, electionPath, builder.id);
+    log.debug(builder.id + " is trying to become the leader");
+    try {
+      latch.start();
+    } catch (Exception e) {
+      throw new IllegalStateException("Error starting latch for " + electionPath, e);
+    }
+  }
+
+  @Override public Boolean get() {
+    if (!latch.hasLeadership()) return false;
+
+    synchronized (this) {
+      if (System.nanoTime() < nextRun) {
+        return false;
+      } else {
+        nextRun = System.nanoTime() + updateFrequencyNanos;
+        return true;
+      }
+    }
+  }
+
+  @Override public void close() throws IOException {
+    try {
+      latch.close();
+    } catch (IllegalStateException ignored) {
+      // Already closed or has not been started isn't worth raising an exception over.
+    }
+  }
+}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdater.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdater.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.framework.recipes.nodes.GroupMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static zipkin.internal.Util.UTF_8;
+
+/**
+ * This watches the store rate path for updates.
+ */
+final class SampleRateUpdater implements PathChildrenCacheListener, Closeable {
+  final Logger log = LoggerFactory.getLogger(SampleRateUpdater.class);
+
+  private final GroupMember storeRateMember;
+  private final String sampleRatePath;
+  private final Function<Map<String, Integer>, Optional<Float>> calculator;
+  private final Supplier<Boolean> guard;
+  private final PathChildrenCache dataWatcher;
+
+  SampleRateUpdater(CuratorFramework client,
+      GroupMember storeRateMember,
+      String storeRatePath,
+      String sampleRatePath,
+      Function<Map<String, Integer>, Optional<Float>> calculator,
+      Supplier<Boolean> guard
+  ) {
+    this.storeRateMember = storeRateMember;
+    this.sampleRatePath = sampleRatePath;
+    this.calculator = calculator;
+    this.guard = guard;
+    // We don't need to cache the data as we can already access it from storeRateMember
+    this.dataWatcher = new PathChildrenCache(client, storeRatePath, false);
+    try {
+      this.dataWatcher.start();
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+    dataWatcher.getListenable().addListener(this);
+  }
+
+  @Override public void close() throws IOException {
+    dataWatcher.close();
+  }
+
+  @Override public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) {
+    switch (event.getType()) {
+      case CHILD_ADDED:
+      case CHILD_UPDATED:
+      case CHILD_REMOVED:
+        break;
+      default:
+        return;
+    }
+    ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder();
+    for (Map.Entry<String, byte[]> i : storeRateMember.getCurrentMembers().entrySet()) {
+      if (i.getValue() == null) continue;
+      try {
+        builder.put(i.getKey(), Integer.valueOf(new String(i.getValue(), UTF_8)));
+      } catch (NumberFormatException e) {
+        log.debug("malformed data at path {}: {}", i.getKey(), e.getMessage());
+      }
+    }
+    Optional<Float> newSampleRate = calculator.apply(builder.build());
+    if (!newSampleRate.isPresent() || !guard.get()) return;
+    Float rate = newSampleRate.get();
+    log.info("updating sample rate: {} {}", sampleRatePath, rate);
+    try {
+      client.create().creatingParentsIfNeeded()
+          .forPath(sampleRatePath, rate.toString().getBytes(UTF_8));
+    } catch (Exception e) {
+      log.warn("could not set sample rate to {} for {}", rate, sampleRatePath);
+    }
+  }
+}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperSampler.java
@@ -13,23 +13,60 @@
  */
 package zipkin.sampler.zookeeper;
 
-import com.twitter.zipkin.sampler.AdaptiveSampleRate;
-import java.util.Collections;
+import com.google.common.io.Closer;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.nodes.GroupMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zipkin.Sampler;
 import zipkin.Span;
+import zipkin.internal.Util;
 
+import static com.google.common.base.Preconditions.checkState;
 import static zipkin.internal.Util.checkArgument;
 import static zipkin.internal.Util.checkNotNull;
 
-public final class ZooKeeperSampler extends Sampler implements AutoCloseable {
+/**
+ * This is an adaptive sampler which can help prevent a surge in traffic from overwhelming the
+ * zipkin storage layer. It works by coordinating a sample rate based on multiple instances vs a
+ * target storage rate in spans/minute.
+ *
+ * <p>This assumes that each instance is storing every span it {@link #isSampled(Span) samples}, and
+ * that the store rate is a useful metric (ex spans have relatively the same size and depth.
+ *
+ * <p>If the storage layer is capable of 10k spans/minute, you'd set the target rate in ZooKeeper to
+ * 10000. With this in mind, 10 balanced collectors writing 10k spans/minute would eventually see a
+ * sample rate of 0.10, slowing them down to match what the storage is capable of.
+ *
+ * <h3>Implementation notes</h3>
+ *
+ * <p>This object spawns a single scheduling thread that reports its rate of {@link #isSampled(Span)
+ * spans sampled}, per the {@link Builder#updateFrequency(int) update frequency}.
+ *
+ * <p>When a leader, this object summarizes recent sample rates and compares them against a target.
+ *
+ * <p>Algorithms and defaults are tuned to favor decreasing the sample rate vs increasing it. For
+ * example, a surge in writes will fire a rate adjustment faster than a drop in writes.
+ */
+public final class ZooKeeperSampler extends Sampler implements Closeable {
+  final static Logger log = LoggerFactory.getLogger(ZooKeeperSampler.class);
 
-  /** Configuration including defaults needed to consume spans from a Kafka basePath. */
   public static final class Builder {
     float initialRate = 1.0f;
-    String basePath = "/zipkin/sampler/";
-    String zookeeper = "localhost:2181";
+    String basePath = "/zipkin/sampler";
+    String id = UUID.randomUUID().toString();
     int updateFrequency = 30;
     int windowSize = 30 * 60;
     int sufficientWindowSize = 10 * 60;
@@ -42,19 +79,22 @@ public final class ZooKeeperSampler extends Sampler implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Stable name to use for this node in ZooKeeper groups and elections, ex. "cluster@host:port".
+     * Defaults to a UUID.
+     */
+    public Builder id(String id) {
+      this.id = checkNotNull(id, "id");
+      return this;
+    }
+
     /** Base path in ZooKeeper for the sampler to use. Defaults to "zipkin" */
     public Builder basePath(String basePath) {
       this.basePath = checkNotNull(basePath, "basePath");
       return this;
     }
 
-    /** The zookeeper connect string, Defaults to 127.0.0.1:2181 */
-    public Builder zookeeper(String zookeeper) {
-      this.zookeeper = checkNotNull(zookeeper, "zookeeper");
-      return this;
-    }
-
-    /** Frequency in seconds which to update the sample rate. Defaults to 30 */
+    /** Frequency in seconds which to update the store and sample rate. Defaults to 30 */
     public Builder updateFrequency(int updateFrequency) {
       checkArgument(updateFrequency >= 1, "updateFrequency must be at least 1 second");
       this.updateFrequency = updateFrequency;
@@ -82,34 +122,107 @@ public final class ZooKeeperSampler extends Sampler implements AutoCloseable {
       return this;
     }
 
-    public ZooKeeperSampler build() {
-      return new ZooKeeperSampler(this);
+    /**
+     * @param client must be started, and will not be closed on {@link #close()}
+     */
+    public ZooKeeperSampler build(CuratorFramework client) {
+      checkState(checkNotNull(client, "client").getState() == CuratorFrameworkState.STARTED,
+          "%s is not started", client.getState());
+      return new ZooKeeperSampler(this, client);
     }
   }
 
+  final String groupMember;
   final AtomicLong boundary;
   final AtomicInteger spanCount;
-  final AdaptiveSampleRate sampleRate;
+  final AtomicInteger storeRate;
+  final Closer closer = Closer.create();
 
-  ZooKeeperSampler(Builder builder) {
-    this.boundary = new AtomicLong((long) (Long.MAX_VALUE * builder.initialRate)); // safe cast as less <= 1
-    this.spanCount = new AtomicInteger();
-    this.sampleRate = new AdaptiveSampleRate(
-        boundary,
-        spanCount,
-        builder.zookeeper,
-        Collections.emptyMap(),
-        builder.basePath,
-        builder.updateFrequency,
-        builder.windowSize,
-        builder.sufficientWindowSize,
-        builder.outlierThreshold
-    );
+  ZooKeeperSampler(Builder builder, CuratorFramework client) {
+    groupMember = builder.id;
+    boundary =
+        new AtomicLong((long) (Long.MAX_VALUE * builder.initialRate)); // safe cast as less <= 1
+    spanCount = new AtomicInteger(0);
+    storeRate = new AtomicInteger();
+    GroupMember storeRateMember = storeRateGroup(client, builder, closer, spanCount, storeRate);
+    AtomicInteger targetStoreRate = targetStoreRate(client, builder, closer);
+    AtomicReference<Float> sampleRate = new AtomicReference(builder.initialRate);
+    String sampleRatePath = builder.basePath + "/sampleRate";
+    closer.register(
+        new SampleRateListener(client, sampleRatePath, sampleRate, boundary));
+    closer.register(new SampleRateUpdater(
+        client,
+        storeRateMember,
+        builder.basePath + "/storeRates",
+        sampleRatePath,
+        new SampleRateCalculatorInput(builder, targetStoreRate).andThen(
+            new SampleRateCalculator(targetStoreRate, sampleRate)),
+        closer.register(new SampleRateUpdateGuard(client, builder))));
+  }
+
+  static GroupMember storeRateGroup(CuratorFramework client, Builder builder, Closer closer,
+      AtomicInteger spanCount, AtomicInteger storeRate) {
+    String storeRatePath = ensureExists(client, builder.basePath + "/storeRates");
+
+    GroupMember storeRateGroup =
+        closer.register(new GroupMember(client, storeRatePath, builder.id));
+
+    log.debug("{} is to join the group {}", builder.id, storeRatePath);
+    storeRateGroup.start();
+
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    closer.register(executor::shutdown);
+
+    ScheduledFuture<?> future = executor.scheduleAtFixedRate(() -> {
+      int oldValue = storeRate.get();
+      int newValue = (int) (1.0 * spanCount.getAndSet(0) * 60 / builder.updateFrequency);
+      log.debug("Store rates was: {} now {}", oldValue, newValue);
+      if (oldValue != newValue) {
+        storeRate.set(newValue);
+        storeRateGroup.setThisData(Integer.valueOf(newValue).toString().getBytes());
+      }
+    }, 0, builder.updateFrequency, TimeUnit.SECONDS);
+
+    closer.register(() -> future.cancel(true));
+    return storeRateGroup;
+  }
+
+  /** read-only */
+  static AtomicInteger targetStoreRate(CuratorFramework client, Builder builder, Closer closer) {
+    String targetStoreRatePath = ensureExists(client, builder.basePath + "/targetStoreRate");
+    NodeCache cache = closer.register(new NodeCache(client, targetStoreRatePath));
+    try {
+      cache.start();
+    } catch (Exception e) {
+      throw new IllegalStateException("Error starting cache for " + targetStoreRatePath, e);
+    }
+
+    AtomicInteger targetStoreRate = new AtomicInteger();
+    cache.getListenable().addListener(() -> {
+      byte[] bytes = cache.getCurrentData().getData();
+      if (bytes.length == 0) return;
+      try {
+        targetStoreRate.set(Integer.valueOf(new String(bytes, Util.UTF_8)));
+      } catch (NumberFormatException e) {
+        log.warn("Error parsing target store rate {}", e.getMessage());
+        return;
+      }
+    });
+    return targetStoreRate;
+  }
+
+  static String ensureExists(CuratorFramework client, String path) {
+    try {
+      client.checkExists().creatingParentContainersIfNeeded().forPath(path);
+      return path;
+    } catch (Exception e) {
+      throw new IllegalStateException("Error creating " + path, e);
+    }
   }
 
   @Override
-  public void close() {
-    this.sampleRate.close();
+  public void close() throws IOException {
+    closer.close();
   }
 
   @Override public boolean isSampled(Span span) {

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorInputTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorInputTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+import static com.google.common.primitives.Ints.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SampleRateCalculatorInputTest {
+
+  @Test public void presentWhenTargetIsPositive() {
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+        .windowSize(1)
+        .updateFrequency(1)
+        .sufficientWindowSize(1)
+        .outlierThreshold(1), new AtomicInteger(1));
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 10)))
+        .isPresent();
+
+    rates.target.set(0);
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 10)))
+        .isEmpty();
+  }
+
+  @Test public void emptyWhenInsufficientData() {
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+        .windowSize(3)
+        .sufficientWindowSize(2)
+        .updateFrequency(1)
+        .outlierThreshold(1), new AtomicInteger(1));
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 10)))
+        .isEmpty();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 20)))
+        .isPresent();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 30)))
+        .isPresent();
+  }
+
+  @Test public void emptyWhenElementIsNotPositive() {
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+        .windowSize(1)
+        .updateFrequency(1)
+        .sufficientWindowSize(1)
+        .outlierThreshold(1), new AtomicInteger(1));
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 10)))
+        .contains(asList(10));
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host2:8080", 0)))
+        .isEmpty();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 30)))
+        .isPresent();
+  }
+
+  @Test public void emptyUntilEnoughOutliers() {
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+        .windowSize(3)
+        .sufficientWindowSize(1)
+        .updateFrequency(1)
+        .outlierThreshold(2), new AtomicInteger(20)); // <17 or >23 is an outlier
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 25)))
+        .isEmpty();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 20))) // not outlier
+        .isEmpty();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 25)))
+        .isEmpty();
+
+    assertThat(rates.apply(ImmutableMap.of("zipkin-server@host:8080", 25)))
+        .isPresent();
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+import static com.google.common.primitives.Ints.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class SampleRateCalculatorTest {
+
+  @Test public void discountedAverage() {
+    assertThat(SampleRateCalculator.discountedAverage(asList(10, 5, 0), 1.0f))
+        .isEqualTo(5); // normal average
+
+    assertThat(SampleRateCalculator.discountedAverage(asList(10, 5, 0), 0.09f))
+        .isEqualTo(9); // smaller discount rate prefers larger numbers
+
+    assertThat(SampleRateCalculator.discountedAverage(asList(1000, 5, 0), 0.09f))
+        .isEqualTo(911);
+  }
+
+  @Test public void lowersRateToDiscountedAverage() {
+    AtomicInteger targetStoreRate = new AtomicInteger(100);
+    AtomicReference<Float> sampleRate = new AtomicReference(1.0f);
+
+    SampleRateCalculator calc = new SampleRateCalculator(targetStoreRate, sampleRate);
+
+    assertThat(calc.apply(Optional.of(asList(1000, 1000, 1000))))
+        .contains(0.1f); // lowered from 1.0 to 0.1
+  }
+
+  /** A collector rebooting shouldn't affect the rate */
+  @Test public void discountsSmallMeasurements() {
+    AtomicInteger targetStoreRate = new AtomicInteger(100);
+    AtomicReference<Float> sampleRate = new AtomicReference(1.0f);
+
+    SampleRateCalculator calc = new SampleRateCalculator(targetStoreRate, sampleRate);
+
+    assertThat(calc.apply(Optional.of(asList(10000, 10000, 150))).get())
+        .isCloseTo(0.01f, withPercentage(2));
+  }
+
+  /** A surge in traffic should immediately affect the rate */
+  @Test public void doesntDiscountBigMeasurements() {
+    AtomicInteger targetStoreRate = new AtomicInteger(100);
+    AtomicReference<Float> sampleRate = new AtomicReference(1.0f);
+
+    SampleRateCalculator calc = new SampleRateCalculator(targetStoreRate, sampleRate);
+
+    assertThat(calc.apply(Optional.of(asList(10000, 10000, 10000000))).get())
+        .isCloseTo(0.0012f, withPercentage(2));
+  }
+
+  @Test public void returnsEmptyWhenRateChangeWithin5Percent() {
+    AtomicInteger targetStoreRate = new AtomicInteger(100);
+    AtomicReference<Float> sampleRate = new AtomicReference(0.1f);
+
+    SampleRateCalculator calc = new SampleRateCalculator(targetStoreRate, sampleRate);
+
+    assertThat(calc.apply(Optional.of(asList(105, 105, 105))))
+        .isEmpty();
+
+    assertThat(calc.apply(Optional.of(asList(110, 110, 110))).get())
+        .isCloseTo(0.09f, withPercentage(2));
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateListenerTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateListenerTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SampleRateListenerTest {
+  static final String PREFIX = "/" + SampleRateListenerTest.class.getSimpleName();
+
+  @Rule public ZooKeeperRule zookeeper = new ZooKeeperRule();
+
+  AtomicReference<Float> sampleRate = new AtomicReference<>(1.0f);
+  AtomicLong boundary = new AtomicLong(Long.MAX_VALUE);
+  SampleRateListener listener;
+
+  @Before
+  public void openThings() throws IOException {
+    listener =
+        new SampleRateListener(zookeeper.client, PREFIX + "/sampleRate", sampleRate, boundary);
+  }
+
+  @After
+  public void closeThings() throws IOException {
+    listener.close();
+  }
+
+  @Test
+  public void idempotentClose() throws Exception {
+    listener.close();
+    listener.close();
+  }
+
+  @Test public void ignoresBadRateReadFromZookeeper() throws Exception {
+    // Simulates a bad rate, set from connectString
+    zookeeper.create(PREFIX + "/sampleRate", "1.9");
+
+    assertThat(listener.sampleRate.get())
+        .isEqualTo(1.0f); // didn't change
+    assertThat(listener.boundary.get())
+        .isEqualTo(Long.MAX_VALUE); // didn't change
+  }
+
+  @Test
+  public void setsRateAndBoundary() throws Exception {
+    zookeeper.create(PREFIX + "/sampleRate", "0.9");
+
+    assertThat(listener.sampleRate.get())
+        .isEqualTo(0.9f);
+    assertThat(listener.boundary.get())
+        .isEqualTo((long) (Long.MAX_VALUE * 0.9f));
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdateGuardTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdateGuardTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import com.google.common.io.Closer;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.test.InstanceSpec;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Inspired by mesos chronos JobSchedulerElectionSpec
+ *
+ * <p>https://github.com/mesos/chronos/blob/master/src/test/scala/org/apache/mesos/chronos/scheduler/jobs/JobSchedulerElectionSpec.scala
+ */
+public class SampleRateUpdateGuardTest {
+  @Rule public ZooKeeperRule zookeeper = new ZooKeeperRule();
+  Closer closer = Closer.create();
+
+  @After
+  public void closeThings() throws IOException {
+    closer.close();
+  }
+
+  @Test
+  public void idempotentClose() throws Exception {
+    SampleRateUpdateGuard guard = guard(new ZooKeeperSampler.Builder());
+    guard.close();
+    guard.close();
+  }
+
+  @Test
+  public void passesWhenALeader() throws Exception {
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+
+    waitForALeader(guard1, guard2);
+
+    SampleRateUpdateGuard leader = guard1.latch.hasLeadership() ? guard1 : guard2;
+    SampleRateUpdateGuard follower = guard1 != leader ? guard1 : guard2;
+
+    assertThat(leader.get()).isTrue();
+
+    assertThat(follower.get()).isFalse();
+  }
+
+  @Test
+  public void onlyPassesOncePerInterval() throws Exception {
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder().updateFrequency(1));
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder().updateFrequency(1));
+
+    waitForALeader(guard1, guard2);
+
+    // should pass immediately
+    SampleRateUpdateGuard leader = guard1.latch.hasLeadership() ? guard1 : guard2;
+
+    int updates = 0;
+    long start = System.nanoTime();
+    // should pass only once, as the interval is 1 second, and we only loop for 1.5s
+    while (System.nanoTime() < start + TimeUnit.MILLISECONDS.toNanos(1500)) {
+      if (leader.get()) updates++;
+      Thread.sleep(10);
+    }
+
+    assertThat(updates).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldElectOnlyOneLeader() throws Exception {
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+
+    waitForALeader(guard1, guard2);
+
+    assertThat(guard1.latch.hasLeadership() ^ guard2.latch.hasLeadership())
+        .withFailMessage("One guard, but not both, should be the leader")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldStillBeOneLeaderAfterZKFailure() throws Exception {
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+
+    waitForALeader(guard1, guard2);
+
+    SampleRateUpdateGuard leader = guard1.latch.hasLeadership() ? guard1 : guard2;
+
+    InstanceSpec instance = zookeeper.cluster.findConnectionInstance(
+        leader.client.getZookeeperClient().getZooKeeper());
+    zookeeper.cluster.killServer(instance);
+
+    waitForALeader(guard1, guard2);
+
+    assertThat(guard1.latch.hasLeadership() ^ guard2.latch.hasLeadership())
+        .withFailMessage("After a ZK node failure, one guard, but not both, should be the leader")
+        .isTrue();
+  }
+
+  @Test
+  public void electsNewLeaderOnClose() throws Exception {
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+
+    waitForALeader(guard1, guard2);
+
+    SampleRateUpdateGuard leader = guard1.latch.hasLeadership() ? guard1 : guard2;
+    SampleRateUpdateGuard follower = guard1 != leader ? guard1 : guard2;
+
+    leader.close();
+
+    waitForALeader(guard1, guard2);
+
+    assertThat(leader.latch.hasLeadership())
+        .withFailMessage("Leader latch should lose leadership on close")
+        .isFalse();
+
+    assertThat(follower.latch.hasLeadership())
+        .withFailMessage("Former follower should be the leader on master failure")
+        .isTrue();
+  }
+
+  int count = 0;
+
+  SampleRateUpdateGuard guard(ZooKeeperSampler.Builder builder) {
+    builder.id("guard-" + count++);
+    return closer.register(new SampleRateUpdateGuard(zookeeper.client, builder));
+  }
+
+  void waitForALeader(SampleRateUpdateGuard... guards) throws InterruptedException {
+    for (int i = 0; i < 100; i++) {
+      for (SampleRateUpdateGuard guard : guards) {
+        if (guard.latch.hasLeadership()) return;
+      }
+      Thread.sleep(100);
+    }
+    throw new AssertionError("No guards became a leader");
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdaterTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdaterTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import com.google.common.io.Closer;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.curator.framework.recipes.nodes.GroupMember;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+public class SampleRateUpdaterTest {
+  static final String PREFIX = "/" + SampleRateUpdaterTest.class.getSimpleName();
+  static final String storeRatePath = PREFIX + "/storeRates";
+
+  @Rule public ZooKeeperRule zookeeper = new ZooKeeperRule();
+
+  GroupMember local;
+  GroupMember peer;
+
+  @Test public void readsAllChildren() throws Exception {
+    Map<String, Integer> inputs = new ConcurrentHashMap<>();
+
+    Function<Map<String, Integer>, Optional<Float>> calculator = (input) -> {
+      inputs.putAll(input);
+      return Optional.empty();
+    };
+
+    updater(calculator, () -> Boolean.TRUE);
+
+    local.setThisData("100".getBytes());
+    peer.setThisData("200".getBytes());
+    zookeeper.sleepABit();
+
+    assertThat(inputs).containsOnly(
+        entry("zipkin-server@1.1.1.1:8080", 100),
+        entry("zipkin-server@2.2.2.2:8080", 200)
+    );
+  }
+
+  /**
+   * If a collector node goes down, or is renamed, we shouldn't read the old key, as it would skew
+   * the sample rate.
+   */
+  @Test public void onlyReadsCurrentGroupMembers() throws Exception {
+    Map<String, Integer> inputs = new ConcurrentHashMap<>();
+
+    Function<Map<String, Integer>, Optional<Float>> calculator = (input) -> {
+      inputs.putAll(input);
+      return Optional.empty();
+    };
+
+    updater(calculator, () -> Boolean.TRUE);
+
+    local.setThisData("100".getBytes());
+    peer.setThisData("200".getBytes());
+    zookeeper.sleepABit();
+
+    assertThat(inputs).containsOnly(
+        entry("zipkin-server@1.1.1.1:8080", 100),
+        entry("zipkin-server@2.2.2.2:8080", 200)
+    );
+    inputs.clear();
+
+    // Simulate a peer going down and the local node taking over the load
+    peer.close();
+    local.setThisData("300".getBytes());
+    zookeeper.sleepABit();
+
+    assertThat(inputs).containsOnly(
+        entry("zipkin-server@1.1.1.1:8080", 300)
+    );
+  }
+
+  @Test public void skipsMalformedData() throws Exception {
+    Map<String, Integer> inputs = new ConcurrentHashMap<>();
+
+    Function<Map<String, Integer>, Optional<Float>> calculator = (input) -> {
+      inputs.putAll(input);
+      return Optional.empty();
+    };
+
+    updater(calculator, () -> Boolean.TRUE);
+
+    local.setThisData("crying babies".getBytes());
+    peer.setThisData("200".getBytes());
+    zookeeper.sleepABit();
+
+    assertThat(inputs).containsOnly(
+        entry("zipkin-server@2.2.2.2:8080", 200)
+    );
+  }
+
+  @Test public void writesSampleRate() throws Exception {
+    updater((input) -> Optional.of(0.9f), () -> Boolean.TRUE);
+
+    local.setThisData("100".getBytes()); // trigger
+    zookeeper.sleepABit();
+
+    assertThat(zookeeper.client.getData().forPath(PREFIX + "/sampleRate"))
+        .isEqualTo("0.9".getBytes());
+  }
+
+  @Test public void obeysGuard() throws Exception {
+    updater((input) -> Optional.of(0.9f), () -> Boolean.FALSE);
+
+    local.setThisData("100".getBytes());
+    zookeeper.sleepABit();
+
+    assertThat(zookeeper.client.checkExists().forPath(PREFIX + "/sampleRate"))
+        .isNull();
+  }
+
+  Closer closer = Closer.create();
+
+  SampleRateUpdater updater(Function<Map<String, Integer>, Optional<Float>> calculator,
+      Supplier<Boolean> guard) {
+    return closer.register(new SampleRateUpdater(
+        zookeeper.client, local, storeRatePath, PREFIX + "/sampleRate", calculator, guard));
+  }
+
+  @Before
+  public void joinGroup() throws Exception {
+    zookeeper.client.createContainers(storeRatePath);
+    local = closer.register(
+        new GroupMember(zookeeper.client, storeRatePath, "zipkin-server@1.1.1.1:8080"));
+    peer = closer.register(
+        new GroupMember(zookeeper.client, storeRatePath, "zipkin-server@2.2.2.2:8080"));
+    local.start();
+    peer.start();
+    zookeeper.sleepABit(); // for the group members to start
+  }
+
+  @After
+  public void closeThings() throws IOException {
+    closer.close();
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperRule.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperRule.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.sampler.zookeeper;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.Timing;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import zipkin.internal.Util;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.curator.framework.CuratorFrameworkFactory.newClient;
+
+final class ZooKeeperRule implements TestRule {
+  TestingCluster cluster;
+  CuratorFramework client;
+  Timing timing = new Timing();
+
+  void sleepABit() throws InterruptedException {
+    timing.sleepABit();
+  }
+
+  void create(String path, String data) throws Exception {
+    client.createContainers(path);
+    client.setData().forPath(path, data.getBytes(Util.UTF_8));
+    sleepABit();
+  }
+
+  @Override public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        try {
+          cluster = new TestingCluster(3);
+          cluster.start();
+
+          client = newClient(cluster.getConnectString(), new RetryOneTime(200 /* ms */));
+          client.start();
+
+          checkState(client.blockUntilConnected(5, TimeUnit.SECONDS),
+              "failed to connect to zookeeper in 5 seconds");
+
+          base.evaluate();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("Interrupted while connecting to ZooKeeper", e);
+        } finally {
+          client.close();
+          cluster.close();
+        }
+      }
+    };
+  }
+}

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperSamplerTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperSamplerTest.java
@@ -13,15 +13,9 @@
  */
 package zipkin.sampler.zookeeper;
 
-import java.io.IOException;
-import java.util.List;
 import java.util.Random;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.retry.RetryOneTime;
-import org.apache.curator.test.TestingServer;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.Constants;
@@ -31,16 +25,29 @@ import zipkin.Span;
 import zipkin.internal.CallbackCaptor;
 
 import static java.util.Arrays.asList;
-import static org.apache.curator.framework.CuratorFrameworkFactory.newClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;
 
 public class ZooKeeperSamplerTest {
+  static final String PREFIX = "/" + ZooKeeperSamplerTest.class.getSimpleName();
+  @Rule public ZooKeeperRule zookeeper = new ZooKeeperRule();
+
   InMemoryStorage storage = new InMemoryStorage();
+  ZooKeeperSampler sampler;
+
+  @Before public void clear() throws Exception {
+    if (sampler != null) {
+      sampler.close();
+    }
+    sampler = new ZooKeeperSampler.Builder()
+        .basePath(PREFIX)
+        .updateFrequency(1) // least possible value
+        .build(zookeeper.client);
+  }
 
   @Test public void sampleRateReadFromZookeeper() throws Exception {
-    // Simulates an existing sample rate, set from zookeeper
-    client.setData().forPath("/sampleRate", "0.9".getBytes());
+    // Simulates an existing sample rate, set from connectString
+    zookeeper.create(PREFIX + "/sampleRate", "0.9");
 
     accept(spans);
 
@@ -48,39 +55,32 @@ public class ZooKeeperSamplerTest {
         .isCloseTo((int) (spans.length * 0.9), withinPercentage(3));
   }
 
-  @Test public void ignoresBadRateReadFromZookeeper() throws Exception {
-    // Simulates a bad rate, set from zookeeper
-    client.setData().forPath("/sampleRate", "1.9".getBytes());
-
-    accept(spans);
-
-    assertThat(storage.acceptedSpanCount())
-        .isEqualTo(spans.length); // default is retain all
-  }
-
   @Test public void exportsStoreRateToZookeeperOnInterval() throws Exception {
     accept(spans);
 
     // Until the update interval, we'll see a store rate of zero
-    assertThat(getLocalStoreRate()).isZero();
+    assertThat(sampler.storeRate.get()).isZero();
 
     // Await until update interval passes (1 second + fudge)
     Thread.sleep(1000); // let the update interval pass
 
     // since update frequency is secondly, the rate exported to ZK will be the amount stored * 60
-    assertThat(getLocalStoreRate())
+    assertThat(sampler.storeRate.get())
         .isEqualTo(spans.length * 60);
+    assertThat(storeRateFromZooKeeper(sampler.groupMember))
+        .isEqualTo(sampler.storeRate.get());
   }
 
-  @Before public void clear() throws Exception {
-    // default to always sample
-    client.setData().forPath("/sampleRate", "1.0".getBytes());
+  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
+  void accept(Span... spans) {
+    CallbackCaptor<Void> captor = new CallbackCaptor<>();
+    storage.asyncSpanConsumer(sampler).accept(asList(spans), captor);
+    captor.get(); // block on result
+  }
 
-    // remove any storage rate members
-    List<String> groupMembers = client.getChildren().forPath("/storeRates");
-    if (!groupMembers.isEmpty()) {
-      client.setData().forPath("/storeRates/" + groupMembers.get(0), new byte[] {'0'});
-    }
+  int storeRateFromZooKeeper(String id) throws Exception {
+    byte[] data = zookeeper.client.getData().forPath(PREFIX + "/storeRates/" + id);
+    return data.length == 0 ? 0 : Integer.parseInt(new String(data));
   }
 
   /**
@@ -93,52 +93,6 @@ public class ZooKeeperSamplerTest {
     Endpoint e = Endpoint.create("service", 127 << 24 | 1, 8080);
     Annotation ann = Annotation.create(System.currentTimeMillis() * 1000, Constants.SERVER_RECV, e);
     return new Span.Builder().traceId(traceId).id(traceId).name("get").addAnnotation(ann).build();
-  }
-
-  static CuratorFramework client;
-  static TestingServer zookeeper;
-  static ZooKeeperSampler sampler;
-
-  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
-  void accept(Span... spans) {
-    CallbackCaptor<Void> captor = new CallbackCaptor<>();
-    storage.asyncSpanConsumer(sampler).accept(asList(spans), captor);
-    captor.get(); // block on result
-  }
-
-  @BeforeClass public static void beforeAll() throws Exception {
-    zookeeper = new TestingServer();
-    client = newClient(zookeeper.getConnectString(), new RetryOneTime(200 /* ms */));
-    zookeeper.start();
-    client.start();
-    // ZooKeeperSampler doesn't create these!
-    client.createContainers("/election");
-    client.createContainers("/storeRates");
-    client.createContainers("/sampleRate");
-    client.createContainers("/targetStoreRate");
-
-    sampler = new ZooKeeperSampler.Builder()
-        .zookeeper(zookeeper.getConnectString())
-        .basePath("") // shorten for test readability
-        .updateFrequency(1) // least possible value
-        .build();
-
-    // prime zookeeper data, to make sure connection-concerns don't fail tests
-    sampler.isSampled(spans[0]);
-    Thread.sleep(1000); // let the update interval pass
-  }
-
-  @AfterClass public static void afterAll() throws IOException {
-    client.close();
-    zookeeper.close();
-    sampler.close();
-  }
-
-  /** Twitter's zookeeper group is where you store the same value as a child node */
-  static int getLocalStoreRate() throws Exception {
-    String groupMember = client.getChildren().forPath("/storeRates").get(0);
-    byte[] data = client.getData().forPath("/storeRates/" + groupMember);
-    return data.length == 0 ? 0 : Integer.parseInt(new String(data));
   }
 }
 

--- a/zipkin-samplers/zookeeper/src/test/resources/log4j.properties
+++ b/zipkin-samplers/zookeeper/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=WARN, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p %c %x %m [%t]%n

--- a/zipkin-samplers/zookeeper/src/test/resources/logback.xml
+++ b/zipkin-samplers/zookeeper/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="zipkin.sampler.zookeeper" level="DEBUG"/>
+
+  <!-- don't waste logs when ZK check fails -->
+  <logger name="org.apache.zookeeper.ClientCnxn" level="OFF"/>
+  <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="OFF"/>
+  <logger name="org.apache.zookeeper.server.quorum" level="OFF"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This implements the adaptive sampler in Java using Apache Curator. The
expected result is the same functionality with fewer build and runtime
dependencies.

Example:

```java
// The ZooKeeperSampler requires you to supply your own Curator.
client = CuratorFrameworkFactory.builder()
    .connectString(zookeeperConnect)
    .retryPolicy(new RetryOneTime(1))
    .build();
client.start();
client.blockUntilConnected(3, TimeUnit.SECONDS);

// This will sample spans based on the capacity of the storage layer.
// Capacity is spans/minute and set by an admin.
sampler = new ZooKeeperSampler.Builder()
    .id("kafka-" + topic + "@" + hostAndPort)
    .build(client);

// Initialize a collector that will sample incoming spans based on
// a coordinated rate.
collector = new KafkaCollector.Builder()
    .zookeeper(zookeeperConnect)
    .topic(topic)
    .writeTo(storage, sampler);
```