### PR TITLE
Updates to Brave 3.6 and makes self-tracing optional

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -22,6 +22,19 @@ To run the server from the currently checked out source, enter the following.
 $ ./mvnw -pl zipkin-server spring-boot:run
 ```
 
+## Self-Tracing
+Self tracing exists to help troubleshoot performance of the zipkin-server.
+
+When Brave dependencies are in the classpath, and `zipkin.self-tracing.enabled=true`,
+Zipkin will self-trace calls to the api.
+
+[yaml configuration](zipkin-server/src/main/resources/zipkin-server.yml) binds the following environment variables to spring properties:
+
+Variable | Property | Description
+--- | --- | ---
+SELF_TRACING_ENABLED | zipkin.self-tracing.enabled | Set to false to disable self-tracing. Defaults to true
+SELF_TRACING_FLUSH_INTERVAL | zipkin.self-tracing.flush-interval | Interval in seconds to flush self-tracing data to storage. Defaults to 1
+
 ## Configuration for the UI
 Zipkin has a web UI, which is enabled by default when you depend on `io.zipkin:zipkin-ui`. This UI is automatically included in the exec jar, and is hosted by default on port 9411.
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <brave.version>3.5.0</brave.version>
+    <brave.version>3.6.0</brave.version>
     <zipkin-ui.version>1.39.6</zipkin-ui.version>
     <start-class>zipkin.server.ZipkinServer</start-class>
     <maven-invoker-plugin.version>2.0.0</maven-invoker-plugin.version>
@@ -137,13 +137,6 @@
     <dependency>
       <groupId>com.github.kristofa</groupId>
       <artifactId>brave-spring-web-servlet-interceptor</artifactId>
-      <version>${brave.version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.kristofa</groupId>
-      <artifactId>brave-spancollector-scribe</artifactId>
       <version>${brave.version}</version>
       <optional>true</optional>
     </dependency>

--- a/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
@@ -22,7 +22,9 @@ import com.github.kristofa.brave.spring.ServletHandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
@@ -31,6 +33,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
 @ConditionalOnClass(DefaultSpanNameProvider.class) // makes brave-http an optional dep
+@ConditionalOnBean(Brave.class)
 public class ApiTracerConfiguration extends WebMvcConfigurerAdapter {
 
   @Autowired

--- a/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -13,18 +13,14 @@
  */
 package zipkin.server.brave;
 
+import com.github.kristofa.brave.AbstractSpanCollector;
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanCollector;
-import com.twitter.zipkin.gen.AnnotationType;
-import java.io.Flushable;
-import java.util.ArrayList;
+import com.twitter.zipkin.gen.SpanCodec;
+import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import zipkin.Annotation;
 import zipkin.AsyncSpanConsumer;
-import zipkin.BinaryAnnotation;
-import zipkin.BinaryAnnotation.Type;
-import zipkin.Endpoint;
+import zipkin.Codec;
 import zipkin.Sampler;
 import zipkin.Span;
 import zipkin.SpanStore;
@@ -33,109 +29,24 @@ import zipkin.StorageComponent;
 /**
  * A Brave {@link SpanCollector} that forwards to the local {@link SpanStore}.
  */
-public class SpanStoreSpanCollector implements SpanCollector, Flushable {
+public class SpanStoreSpanCollector extends AbstractSpanCollector {
   private final StorageComponent storage;
-  // TODO: should we put a bound on this queue?
-  // Since this is only used for internal tracing in zipkin, maybe it's ok
-  private final BlockingQueue<Span> queue = new LinkedBlockingQueue<>();
-  private final int limit = 200;
 
-  public SpanStoreSpanCollector(StorageComponent storage) {
+  public SpanStoreSpanCollector(StorageComponent storage, int flushInterval) {
+    super(SpanCodec.JSON, new EmptySpanCollectorMetricsHandler(), checkPositive(flushInterval));
     this.storage = storage;
   }
 
-  public void collect(Span span) {
-    if (queue.offer(span) && queue.size() >= limit) {
-      flush();
+  private static int checkPositive(int flushInterval) {
+    if (flushInterval <= 0) {
+      throw new IllegalArgumentException("flushInterval must be a positive duration in seconds");
     }
+    return flushInterval;
   }
 
   @Override
-  public void collect(com.twitter.zipkin.gen.Span span) {
-    collect(convert(span));
-  }
-
-  @Override
-  public void flush() {
-    List<Span> spans = new ArrayList<>(queue.size());
-    while (!queue.isEmpty()) {
-      Span span = queue.poll();
-      if (span != null) {
-        spans.add(span);
-      }
-    }
-    if (spans.isEmpty()) return;
+  protected void sendSpans(byte[] json) throws IOException {
+    List<Span> spans = Codec.JSON.readSpans(json);
     storage.asyncSpanConsumer(Sampler.ALWAYS_SAMPLE).accept(spans, AsyncSpanConsumer.NOOP_CALLBACK);
-  }
-
-  private Span convert(com.twitter.zipkin.gen.Span span) {
-    Span.Builder builder = new Span.Builder();
-    builder.name(span.getName())
-        .id(span.getId())
-        .parentId(span.getParent_id() != null ? span.getParent_id() : null)
-        .traceId(span.getTrace_id())
-        .timestamp(span.getTimestamp())
-        .duration(span.getDuration())
-        .debug(span.isDebug());
-    List<com.twitter.zipkin.gen.Annotation> annotations = span.getAnnotations();
-    if (annotations != null) {
-      for (com.twitter.zipkin.gen.Annotation annotation : annotations) {
-        builder.addAnnotation(convert(annotation));
-      }
-    }
-    List<com.twitter.zipkin.gen.BinaryAnnotation> binaries = span.getBinary_annotations();
-    if (binaries != null) {
-      for (com.twitter.zipkin.gen.BinaryAnnotation annotation : binaries) {
-        builder.addBinaryAnnotation(convert(annotation));
-      }
-    }
-    return builder.build();
-  }
-
-  @Override
-  public void addDefaultAnnotation(String key, String value) {
-  }
-
-  static Annotation convert(com.twitter.zipkin.gen.Annotation annotation) {
-    return new Annotation.Builder()
-        .timestamp(annotation.timestamp)
-        .value(annotation.value)
-        .endpoint(convert(annotation.host))
-        .build();
-  }
-
-  static Endpoint convert(com.twitter.zipkin.gen.Endpoint endpoint) {
-    return new Endpoint.Builder()
-        .serviceName(endpoint.service_name)
-        .port(endpoint.port)
-        .ipv4(endpoint.ipv4).build();
-  }
-
-  static BinaryAnnotation convert(com.twitter.zipkin.gen.BinaryAnnotation annotation) {
-    return new BinaryAnnotation.Builder()
-        .key(annotation.key)
-        .value(annotation.getValue())
-        .type(convert(annotation.type))
-        .endpoint(convert(annotation.host))
-        .build();
-  }
-
-  static Type convert(AnnotationType type) {
-    switch (type) {
-      case STRING:
-        return Type.STRING;
-      case DOUBLE:
-        return Type.DOUBLE;
-      case BOOL:
-        return Type.BOOL;
-      case I16:
-        return Type.I16;
-      case I32:
-        return Type.I32;
-      case I64:
-        return Type.I64;
-      default:
-        return Type.BYTES;
-    }
   }
 }

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -40,6 +40,11 @@ scribe:
   category: zipkin
   port: ${COLLECTOR_PORT:9410}
 zipkin:
+  self-tracing:
+    # Set to false to disable self-tracing. Defaults to true
+    enabled: ${SELF_TRACING_ENABLED:true}
+    # Interval in seconds to flush self-tracing data to storage.
+    flush-interval: ${SELF_TRACING_FLUSH_INTERVAL:1}
   collector:
     # percentage to traces to retain
     sample-rate: ${COLLECTOR_SAMPLE_RATE:1.0}


### PR DESCRIPTION
This updates to latest Brave, and makes it possible to configure
self-tracing.

Self tracing exists to help troubleshoot performance of the zipkin-server.

When Brave dependencies are in the classpath, and `zipkin.self-tracing.enabled=true`,
Zipkin will self-trace calls to the api.

[yaml configuration](zipkin-server/src/main/resources/zipkin-server.yml) binds the following environment variables to spring properties:

Variable | Property | Description
--- | --- | ---
SELF_TRACING_ENABLED | zipkin.self-tracing.enabled | Set to false to disable self-tracing. Defaults to true
SELF_TRACING_FLUSH_INTERVAL | zipkin.self-tracing.flush-interval | Interval in seconds to flush self-tracing data to storage. Defaults to 1