### PR TITLE
Names server side of a transport collector

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -1,9 +1,9 @@
 # zipkin-server
 zipkin-server is a [Spring Boot](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) application, packaged as an executable jar. You need JRE 8+ to start zipkin-server.
 
-Span storage and transports are configurable. By default, storage is
-in-memory, the http span transport (POST /spans endpoint) is enabled,
-and the server listens on port 9411.
+Span storage and collectors are configurable. By default, storage is
+in-memory, the http collector (POST /spans endpoint) is enabled, and
+the server listens on port 9411.
 
 ## Endpoints
 
@@ -47,7 +47,7 @@ zipkin-server is a drop-in replacement for the [scala query service](https://git
     * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410 
     * `COLLECTOR_SAMPLE_RATE`: Percentage of traces to retain, defaults to always sample (1.0).
 
-### Cassandra
+### Cassandra Storage
 The following apply when `STORAGE_TYPE` is set to `cassandra`:
 
     * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
@@ -65,7 +65,7 @@ Example usage:
 $ STORAGE_TYPE=cassandra CASSANDRA_CONTACT_POINTS=host1,host2 ./mvnw -pl zipkin-server spring-boot:run
 ```
 
-### MySQL
+### MySQL Storage
 The following apply when `STORAGE_TYPE` is set to `mysql`:
 
     * `MYSQL_DB`: The database to use. Defaults to "zipkin".
@@ -81,7 +81,7 @@ Example usage:
 $ STORAGE_TYPE=mysql MYSQL_USER=root ./mvnw -pl zipkin-server spring-boot:run
 ```
 
-### Elasticsearch
+### Elasticsearch Storage
 The following apply when `STORAGE_TYPE` is set to `elasticsearch`:
 
     * `ES_CLUSTER`: The name of the elasticsearch cluster to connect to. Defaults to "elasticsearch".
@@ -98,7 +98,12 @@ Example usage:
 $ STORAGE_TYPE=elasticsearch ES_CLUSTER=monitoring ES_HOSTS=host1:9300,host2:9300 ./mvnw -pl zipkin-server spring-boot:run
 ```
 
-### Kafka
+### Scribe Collector
+The Scribe collector is enabled by default, configured by the following:
+
+    * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
+
+### Kafka Collector
 The following apply when `KAFKA_ZOOKEEPER` is set:
 
     * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.

--- a/zipkin-server/src/main/java/zipkin/server/EnableZipkinServer.java
+++ b/zipkin-server/src/main/java/zipkin/server/EnableZipkinServer.java
@@ -24,7 +24,7 @@ import zipkin.server.brave.BraveConfiguration;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Import({ZipkinServerConfiguration.class, BraveConfiguration.class, ZipkinQueryApiV1.class, ZipkinHttpTransport.class, ZipkinUiConfiguration.class})
+@Import({ZipkinServerConfiguration.class, BraveConfiguration.class, ZipkinQueryApiV1.class, ZipkinHttpCollector.class, ZipkinUiConfiguration.class})
 public @interface EnableZipkinServer {
 
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -40,18 +40,18 @@ import static zipkin.internal.Util.gunzip;
  * Implements the POST /api/v1/spans endpoint used by instrumentation.
  */
 @RestController
-public class ZipkinHttpTransport {
+public class ZipkinHttpCollector {
   static final String APPLICATION_THRIFT = "application/x-thrift";
 
-  private final SpanConsumerLogger logger = new SpanConsumerLogger(ZipkinHttpTransport.class);
+  private final SpanConsumerLogger logger = new SpanConsumerLogger(ZipkinHttpCollector.class);
   private final AsyncSpanConsumer consumer;
   private final Codec jsonCodec;
   private final Codec thriftCodec;
 
   /** lazy so transient storage errors don't crash bootstrap */
   @Lazy
-  @Autowired
-  ZipkinHttpTransport(StorageComponent storage, Sampler sampler, Codec.Factory codecFactory) {
+  @Autowired ZipkinHttpCollector(StorageComponent storage, Sampler sampler,
+      Codec.Factory codecFactory) {
     this.consumer = storage.asyncSpanConsumer(sampler);
     this.jsonCodec = checkNotNull(codecFactory.get(APPLICATION_JSON_VALUE), APPLICATION_JSON_VALUE);
     this.thriftCodec = checkNotNull(codecFactory.get(APPLICATION_THRIFT), APPLICATION_THRIFT);

--- a/zipkin-transports/kafka/README.md
+++ b/zipkin-transports/kafka/README.md
@@ -1,16 +1,18 @@
 # transport-kafka
-This transport polls a Kafka 8.2.2+ topic for messages that contain
+
+## KafkaCollector
+This collector polls a Kafka 8.2.2+ topic for messages that contain
 a list of spans in json or TBinaryProtocol big-endian encoding. These
 spans are pushed to a span consumer.
 
-`zipkin.kafka.KafkaTransport.Builder` includes defaults that will
+`zipkin.kafka.KafkaCollector.Builder` includes defaults that will
 operate against a Kafka topic advertised in Zookeeper.
 
-### Encoding spans into Kafka messages
+## Encoding spans into Kafka messages
 The message's binary data includes a list of spans. Supported encodings
 are the same as the http [POST /spans](http://zipkin.io/zipkin-api/#/paths/%252Fspans) body.
 
-#### Json
+### Json
 The message's binary data is a list of spans in json. The first character must be '[' (decimal 91).
 
 `Codec.JSON.writeSpans(spans)` performs the correct json encoding.
@@ -22,7 +24,7 @@ $ kafka-console-producer.sh --broker-list $ADVERTISED_HOST:9092 --topic zipkin
 [{"traceId":"1","name":"bang","id":"2","timestamp":1234,"binaryAnnotations":[{"key":"lc","value":"bamm-bamm","endpoint":{"serviceName":"flintstones","ipv4":"127.0.0.1"}}]}]
 ```
 
-#### Thrift
+### Thrift
 The message's binary data includes a list header followed by N spans serialized in TBinaryProtocol
 
 `Codec.THRIFT.writeSpans(spans)` encodes spans in the following fashion:

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
@@ -30,10 +30,10 @@ import static kafka.consumer.Consumer.createJavaConsumerConnector;
 import static zipkin.internal.Util.checkNotNull;
 
 /**
- * This transport polls a Kafka topic for messages that contain TBinaryProtocol big-endian encoded
+ * This collector polls a Kafka topic for messages that contain TBinaryProtocol big-endian encoded
  * lists of spans. These spans are pushed to a {@link AsyncSpanConsumer#accept span consumer}.
  */
-public final class KafkaTransport implements AutoCloseable {
+public final class KafkaCollector implements AutoCloseable {
 
   /** Configuration including defaults needed to consume spans from a Kafka topic. */
   public static final class Builder {
@@ -66,10 +66,10 @@ public final class KafkaTransport implements AutoCloseable {
       return this;
     }
 
-    public KafkaTransport writeTo(StorageComponent storage, Sampler sampler) {
+    public KafkaCollector writeTo(StorageComponent storage, Sampler sampler) {
       checkNotNull(storage, "storage");
       checkNotNull(sampler, "sampler");
-      return new KafkaTransport(this, new Lazy<AsyncSpanConsumer>() {
+      return new KafkaCollector(this, new Lazy<AsyncSpanConsumer>() {
         @Override protected AsyncSpanConsumer compute() {
           return checkNotNull(storage.asyncSpanConsumer(sampler), storage + ".asyncSpanConsumer()");
         }
@@ -80,7 +80,7 @@ public final class KafkaTransport implements AutoCloseable {
   final ConsumerConnector connector;
   final ExecutorService pool;
 
-  KafkaTransport(Builder builder, Lazy<AsyncSpanConsumer> consumer) {
+  KafkaCollector(Builder builder, Lazy<AsyncSpanConsumer> consumer) {
     Map<String, Integer> topicCountMap = new LinkedHashMap<>(1);
     topicCountMap.put(builder.topic, builder.streams);
 

--- a/zipkin-transports/scribe/README.md
+++ b/zipkin-transports/scribe/README.md
@@ -1,12 +1,14 @@
 # transport-scribe
-This transport accepts Scribe logs in a specified category. Each log
+
+## ScribeCollector
+This collector accepts Scribe logs in a specified category. Each log
 entry is expected to contain a single span, which is TBinaryProtocol
 big-endian, then base64 encoded. These spans are then pushed to storage.
 
-`zipkin.scribe.ScribeTransport.Builder` includes defaults that will
+`zipkin.scribe.ScribeCollector.Builder` includes defaults that will
 listen on port 9410, accept log entries in the category "zipkin"
 
-### Encoding
+## Encoding
 The scribe message is a TBinaryProtocol big-endian, then Base64 span.
 Base64 Basic and MIME schemes are supported.
 

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
@@ -27,11 +27,11 @@ import static java.util.Collections.emptyList;
 import static zipkin.internal.Util.checkNotNull;
 
 /**
- * This transport accepts Scribe logs in a specified category. Each log entry is expected to contain
+ * This collector accepts Scribe logs in a specified category. Each log entry is expected to contain
  * a single span, which is TBinaryProtocol big-endian, then base64 encoded. These spans are chained
  * to an {@link GuavaSpanConsumer#accept asynchronous span consumer}.
  */
-public final class ScribeTransport implements AutoCloseable {
+public final class ScribeCollector implements AutoCloseable {
 
   /** Configuration including defaults needed to receive spans from a Scribe category. */
   public static final class Builder {
@@ -50,10 +50,10 @@ public final class ScribeTransport implements AutoCloseable {
       return this;
     }
 
-    public ScribeTransport writeTo(StorageComponent storage, Sampler sampler) {
+    public ScribeCollector writeTo(StorageComponent storage, Sampler sampler) {
       checkNotNull(storage, "storage");
       checkNotNull(sampler, "sampler");
-      return new ScribeTransport(this, new Lazy<AsyncSpanConsumer>() {
+      return new ScribeCollector(this, new Lazy<AsyncSpanConsumer>() {
         @Override protected AsyncSpanConsumer compute() {
           return checkNotNull(storage.asyncSpanConsumer(sampler), storage + ".asyncSpanConsumer()");
         }
@@ -63,7 +63,7 @@ public final class ScribeTransport implements AutoCloseable {
 
   final ThriftServer server;
 
-  ScribeTransport(Builder builder, Lazy<AsyncSpanConsumer> consumer) {
+  ScribeCollector(Builder builder, Lazy<AsyncSpanConsumer> consumer) {
     ScribeSpanConsumer scribe = new ScribeSpanConsumer(builder.category, consumer);
     ThriftServiceProcessor processor =
         new ThriftServiceProcessor(new ThriftCodecManager(), emptyList(), scribe);


### PR DESCRIPTION
This renames the server side of a transport collector.
Ex. KafkaTransport -> KafkaCollector

This maintains the name "transport" in artifacts, as they might include
a reporter one day, and the documentation are valid for both sides.

See https://github.com/openzipkin/openzipkin.github.io/issues/23