### PR TITLE
Adds ElasticsearchSpanStore.MAX_RAW_SPANS to permit large query results

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/SpanBenchmarks.java
@@ -49,8 +49,9 @@ public class SpanBenchmarks {
   }
 
   @Benchmark
-  public Span buildMinimalClientSpan() {
-    Endpoint client = Endpoint.create("", 172 << 24 | 17 << 16 | 3);
+  public Span buildClientOnlySpan() {
+    Endpoint client = Endpoint.create("query", 172 << 24 | 17 << 16 | 3);
+    Endpoint mysql = Endpoint.create("mysql", 172 << 24 | 17 << 16 | 4, 3306);
     return new Span.Builder()
         .traceId(1L)
         .name("")
@@ -59,6 +60,7 @@ public class SpanBenchmarks {
         .duration(31000L)
         .addAnnotation(Annotation.create(1444438900948000L, Constants.CLIENT_SEND, client))
         .addAnnotation(Annotation.create(1444438900979000L, Constants.CLIENT_RECV, client))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, mysql))
         .build();
   }
 

--- a/zipkin/src/main/java/zipkin/BinaryAnnotation.java
+++ b/zipkin/src/main/java/zipkin/BinaryAnnotation.java
@@ -34,7 +34,7 @@ import static zipkin.internal.Util.equal;
  * server side due to rewriting, like "/api/v1/myresource" vs "/myresource. Via the host field, you
  * can see the different points of view, which often help in debugging.
  */
-public final class BinaryAnnotation {
+public final class BinaryAnnotation implements Comparable<BinaryAnnotation> {
 
   /** A subset of thrift base types, except BYTES. */
   public enum Type {
@@ -219,5 +219,12 @@ public final class BinaryAnnotation {
     h *= 1000003;
     h ^= (endpoint == null) ? 0 : endpoint.hashCode();
     return h;
+  }
+
+  /** Provides consistent iteration by {@link #key} */
+  @Override
+  public int compareTo(BinaryAnnotation that) {
+    if (this == that) return 0;
+    return key.compareTo(that.key);
   }
 }

--- a/zipkin/src/main/java/zipkin/Span.java
+++ b/zipkin/src/main/java/zipkin/Span.java
@@ -14,17 +14,16 @@
 package zipkin;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.TreeSet;
 import zipkin.internal.JsonCodec;
 import zipkin.internal.Nullable;
 
 import static zipkin.internal.Util.checkNotNull;
 import static zipkin.internal.Util.equal;
-import static zipkin.internal.Util.list;
+import static zipkin.internal.Util.sortedList;
 
 /**
  * A trace is a series of spans (often RPC calls) which form a latency tree.
@@ -140,8 +139,8 @@ public final class Span implements Comparable<Span> {
     this.parentId = builder.parentId;
     this.timestamp = builder.timestamp;
     this.duration = builder.duration;
-    this.annotations = list(builder.annotations);
-    this.binaryAnnotations = list(builder.binaryAnnotations);
+    this.annotations = sortedList(builder.annotations);
+    this.binaryAnnotations = sortedList(builder.binaryAnnotations);
     this.debug = builder.debug;
   }
 
@@ -152,8 +151,9 @@ public final class Span implements Comparable<Span> {
     Long parentId;
     Long timestamp;
     Long duration;
-    Collection<Annotation> annotations;
-    Collection<BinaryAnnotation> binaryAnnotations;
+    // Not LinkedHashSet, as the constructor makes a sorted copy
+    HashSet<Annotation> annotations;
+    HashSet<BinaryAnnotation> binaryAnnotations;
     Boolean debug;
 
     public Builder() {
@@ -258,14 +258,14 @@ public final class Span implements Comparable<Span> {
      * @see Span#annotations
      */
     public Builder annotations(Collection<Annotation> annotations) {
-      this.annotations = new TreeSet<>(annotations);
+      this.annotations = new HashSet<>(annotations);
       return this;
     }
 
     /** @see Span#annotations */
     public Builder addAnnotation(Annotation annotation) {
       if (annotations == null) {
-        annotations = new TreeSet<>();
+        annotations = new HashSet<>();
       }
       annotations.add(annotation);
       return this;
@@ -277,14 +277,14 @@ public final class Span implements Comparable<Span> {
      * @see Span#binaryAnnotations
      */
     public Builder binaryAnnotations(Collection<BinaryAnnotation> binaryAnnotations) {
-      this.binaryAnnotations = new LinkedHashSet<>(binaryAnnotations);
+      this.binaryAnnotations = new HashSet<>(binaryAnnotations);
       return this;
     }
 
     /** @see Span#binaryAnnotations */
     public Builder addBinaryAnnotation(BinaryAnnotation binaryAnnotation) {
       if (binaryAnnotations == null) {
-        binaryAnnotations = new LinkedHashSet<>();
+        binaryAnnotations = new HashSet<>();
       }
       binaryAnnotations.add(binaryAnnotation);
       return this;
@@ -363,7 +363,7 @@ public final class Span implements Comparable<Span> {
 
   /** Returns the distinct {@link Endpoint#serviceName service names} that logged to this span. */
   public Set<String> serviceNames() {
-    Set<String> result = new LinkedHashSet<>();
+    Set<String> result = new HashSet<>();
     for (Annotation a : annotations) {
       if (a.endpoint == null) continue;
       if (a.endpoint.serviceName.isEmpty()) continue;

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -65,13 +65,9 @@ public final class Util {
     return reference;
   }
 
-  public static <T> List<T> list(@Nullable Collection<T> input) {
-    if (input == null || input.isEmpty()) return Collections.emptyList();
-    return Collections.unmodifiableList(new ArrayList<>(input));
-  }
-
   public static <T extends Comparable<? super T>> List<T> sortedList(@Nullable Collection<T> input) {
     if (input == null || input.isEmpty()) return Collections.emptyList();
+    if (input.size() == 1) return Collections.singletonList(input.iterator().next());
     List<T> result = new ArrayList<>(input);
     Collections.sort(result);
     return Collections.unmodifiableList(result);

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -96,4 +96,20 @@ public class SpanTest {
         .containsOnly(WEB_ENDPOINT.serviceName);
   }
 
+  /** This helps tests not flake out when binary annotations aren't returned in insertion order */
+  @Test
+  public void sortsBinaryAnnotationsByKey() {
+    BinaryAnnotation foo = BinaryAnnotation.create("foo", "bar", WEB_ENDPOINT);
+    BinaryAnnotation baz = BinaryAnnotation.create("baz", "qux", WEB_ENDPOINT);
+    Span span = new Span.Builder()
+        .traceId(12345)
+        .id(666)
+        .name("methodcall")
+        .addBinaryAnnotation(foo)
+        .addBinaryAnnotation(baz)
+        .build();
+
+    assertThat(span.binaryAnnotations)
+        .containsExactly(baz, foo);
+  }
 }


### PR DESCRIPTION
This adds `ElasticsearchSpanStore.MAX_RAW_SPANS`, which controls the maximum
raw spans returned by any trace query, regardless of trace count.

This is similar to `CassandraStorage.maxTraceCols`, which might warrant
renaming.

Fixes #159