### PR TITLE
Makes examples use service names that exist in this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ bytes = Codec.THRIFT.writeSpan(span);
 ```
 
 ## Server
-The [spring-boot server](https://github.com/openzipkin/zipkin-java/tree/master/zipkin-server) receives spans via HTTP POST and respond to queries from zipkin-web. It is a drop-in replacement for the [scala query service](https://github.com/openzipkin/zipkin/tree/master/zipkin-query-service), passing the same tests (via the interop module).
+The [zipkin server](https://github.com/openzipkin/zipkin-java/tree/master/zipkin-server)
+receives spans via HTTP POST and respond to queries from its UI.
+
+The server is a drop-in replacement for the [scala query service](https://github.com/openzipkin/zipkin/tree/master/zipkin-query-service), passing the same tests (via the interop module).
 
 To run the server from the currently checked out source, enter the following.
 ```bash

--- a/zipkin-junit/src/test/java/zipkin/junit/ZipkinDispatcherTest.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/ZipkinDispatcherTest.java
@@ -27,13 +27,13 @@ public class ZipkinDispatcherTest {
   @Test
   public void toQueryRequest() {
     HttpUrl url = baseUrl.newBuilder()
-        .addQueryParameter("serviceName", "zipkin-web")
+        .addQueryParameter("serviceName", "zipkin-server")
         .addQueryParameter("spanName", "get")
         .addQueryParameter("limit", "1000").build();
 
     QueryRequest request = ZipkinDispatcher.toQueryRequest(url);
 
-    assertThat(request.serviceName).isEqualTo("zipkin-web");
+    assertThat(request.serviceName).isEqualTo("zipkin-server");
     assertThat(request.spanName).isEqualTo("get");
     assertThat(request.limit).isEqualTo(1000);
   }
@@ -41,7 +41,7 @@ public class ZipkinDispatcherTest {
   @Test
   public void toQueryRequest_parseAnnotations() {
     HttpUrl url = baseUrl.newBuilder()
-        .addQueryParameter("serviceName", "zipkin-web")
+        .addQueryParameter("serviceName", "zipkin-server")
         .addQueryParameter("annotationQuery", "finagle.retry and finagle.timeout").build();
 
     QueryRequest request = ZipkinDispatcher.toQueryRequest(url);

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -36,7 +36,7 @@ import static zipkin.internal.Util.checkNotNull;
 import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 /**
- * Implements the json api used by {@code zipkin-web}.
+ * Implements the json api used by the Zipkin UI
  *
  * See com.twitter.zipkin.query.ZipkinQueryController
  */

--- a/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/CassandraDependenciesTest.java
@@ -21,7 +21,8 @@ import zipkin.InMemoryStorage;
 import zipkin.Span;
 import zipkin.StorageComponent;
 
-import static java.util.concurrent.TimeUnit.DAYS;
+import static zipkin.TestObjects.DAY;
+import static zipkin.TestObjects.TODAY;
 import static zipkin.internal.Util.midnightUTC;
 
 public class CassandraDependenciesTest extends DependenciesTest {
@@ -53,7 +54,7 @@ public class CassandraDependenciesTest extends DependenciesTest {
   public void processDependencies(List<Span> spans) {
     InMemoryStorage mem = new InMemoryStorage();
     mem.spanConsumer().accept(spans);
-    List<DependencyLink> links = mem.spanStore().getDependencies(today + DAYS.toMillis(1), null);
+    List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
 
     long midnight = midnightUTC(spans.get(0).timestamp / 1000);
     storage.writeDependencyLinks(links, midnight);

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/elasticsearch/ElasticsearchDependenciesTest.java
@@ -21,7 +21,8 @@ import zipkin.InMemoryStorage;
 import zipkin.Span;
 import zipkin.StorageComponent;
 
-import static java.util.concurrent.TimeUnit.DAYS;
+import static zipkin.TestObjects.DAY;
+import static zipkin.TestObjects.TODAY;
 import static zipkin.internal.Util.midnightUTC;
 
 public class ElasticsearchDependenciesTest extends DependenciesTest {
@@ -54,7 +55,7 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
   public void processDependencies(List<Span> spans) {
     InMemoryStorage mem = new InMemoryStorage();
     mem.spanConsumer().accept(spans);
-    List<DependencyLink> links = mem.spanStore().getDependencies(today + DAYS.toMillis(1), null);
+    List<DependencyLink> links = mem.spanStore().getDependencies(TODAY + DAY, null);
 
     long midnight = midnightUTC(spans.get(0).timestamp / 1000);
     storage.writeDependencyLinks(links, midnight);

--- a/zipkin/src/main/java/zipkin/Endpoint.java
+++ b/zipkin/src/main/java/zipkin/Endpoint.java
@@ -40,7 +40,7 @@ public final class Endpoint {
   }
 
   /**
-   * Classifier of a source or destination in lowercase, such as "zipkin-web".
+   * Classifier of a source or destination in lowercase, such as "zipkin-server".
    *
    * <p>This is the primary parameter for trace lookup, so should be intuitive as possible, for
    * example, matching names in service discovery.

--- a/zipkin/src/test/java/zipkin/InternalBlockingToAsyncSpanStoreAdapterTest.java
+++ b/zipkin/src/test/java/zipkin/InternalBlockingToAsyncSpanStoreAdapterTest.java
@@ -50,7 +50,7 @@ public class InternalBlockingToAsyncSpanStoreAdapterTest {
 
   @Test
   public void getTraces_success() {
-    QueryRequest request = new QueryRequest.Builder("zipkin-web").build();
+    QueryRequest request = new QueryRequest.Builder("zipkin-ui").build();
     when(spanStore.getTraces(request)).thenReturn(asList(TRACE));
 
     CallbackCaptor<List<List<Span>>> captor = new CallbackCaptor<>();

--- a/zipkin/src/test/java/zipkin/SpanTest.java
+++ b/zipkin/src/test/java/zipkin/SpanTest.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin.TestObjects.WEB_ENDPOINT;
+import static zipkin.TestObjects.APP_ENDPOINT;
 
 public class SpanTest {
 
@@ -33,7 +33,7 @@ public class SpanTest {
         .traceId(1L)
         .name("")
         .id(1L)
-        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, WEB_ENDPOINT))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, APP_ENDPOINT))
         .build();
 
     Span part2 = new Span.Builder()
@@ -42,8 +42,8 @@ public class SpanTest {
         .id(1L)
         .timestamp(1444438900939000L)
         .duration(376000L)
-        .addAnnotation(Annotation.create(1444438900939000L, Constants.SERVER_RECV, WEB_ENDPOINT))
-        .addAnnotation(Annotation.create(1444438901315000L, Constants.SERVER_SEND, WEB_ENDPOINT))
+        .addAnnotation(Annotation.create(1444438900939000L, Constants.SERVER_RECV, APP_ENDPOINT))
+        .addAnnotation(Annotation.create(1444438901315000L, Constants.SERVER_SEND, APP_ENDPOINT))
         .build();
 
     Span expected = new Span.Builder(part2)
@@ -75,11 +75,11 @@ public class SpanTest {
         .traceId(1L)
         .name("GET")
         .id(1L)
-        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, WEB_ENDPOINT))
+        .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, APP_ENDPOINT))
         .build();
 
     assertThat(span.serviceNames())
-        .containsOnly(WEB_ENDPOINT.serviceName);
+        .containsOnly(APP_ENDPOINT.serviceName);
   }
 
   @Test
@@ -89,18 +89,18 @@ public class SpanTest {
         .id(666)
         .name("methodcall")
         .addAnnotation(Annotation.create(1L, "test", Endpoint.create("", 127 << 24 | 1)))
-        .addAnnotation(Annotation.create(2L, Constants.SERVER_RECV, WEB_ENDPOINT))
+        .addAnnotation(Annotation.create(2L, Constants.SERVER_RECV, APP_ENDPOINT))
         .build();
 
     assertThat(span.serviceNames())
-        .containsOnly(WEB_ENDPOINT.serviceName);
+        .containsOnly(APP_ENDPOINT.serviceName);
   }
 
   /** This helps tests not flake out when binary annotations aren't returned in insertion order */
   @Test
   public void sortsBinaryAnnotationsByKey() {
-    BinaryAnnotation foo = BinaryAnnotation.create("foo", "bar", WEB_ENDPOINT);
-    BinaryAnnotation baz = BinaryAnnotation.create("baz", "qux", WEB_ENDPOINT);
+    BinaryAnnotation foo = BinaryAnnotation.create("foo", "bar", APP_ENDPOINT);
+    BinaryAnnotation baz = BinaryAnnotation.create("baz", "qux", APP_ENDPOINT);
     Span span = new Span.Builder()
         .traceId(12345)
         .id(666)


### PR DESCRIPTION
Names like "zipkin-web" and "zipkin-query" no longer exist