### PR TITLE
Tweaks codec performance and adds benchmarks

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -30,6 +30,8 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <jmh.version>1.12</jmh.version>
+    <libthrift.version>0.9.3</libthrift.version>
+    <zipkin-scrooge.version>1.39.6</zipkin-scrooge.version>
   </properties>
 
   <dependencies>
@@ -49,6 +51,18 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin</groupId>
+      <artifactId>zipkin-scrooge</artifactId>
+      <version>${zipkin-scrooge.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${libthrift.version}</version>
     </dependency>
   </dependencies>
 

--- a/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/CodecBenchmarks.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.benchmarks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.io.ByteStreams;
+import com.twitter.zipkin.conversions.thrift$;
+import com.twitter.zipkin.json.JsonSpan;
+import com.twitter.zipkin.json.JsonSpan$;
+import com.twitter.zipkin.json.ZipkinJson$;
+import com.twitter.zipkin.thriftscala.Span$;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TMemoryBuffer;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin.Codec;
+import zipkin.Span;
+
+/**
+ * This compares the speed of the bundled java codec with the approach used in the scala
+ * implementation. Re-run this benchmark when changing internals of {@link zipkin.Codec}.
+ *
+ * <p>The {@link zipkin.Codec bundled java codec} aims to be both small in size (i.e. does not
+ * significantly increase the size of zipkin's jar), and efficient. It may not always be fastest,
+ * but we should try to keep it competitive.
+ */
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class CodecBenchmarks {
+  static final ObjectReader json_scalaReader = ZipkinJson$.MODULE$.readerFor(JsonSpan.class);
+  static final ObjectWriter json_scalaWriter = ZipkinJson$.MODULE$.writerFor(JsonSpan.class);
+
+  static final byte[] localSpanJson = read("/span-local.json");
+  static final Span localSpan = Codec.JSON.readSpan(localSpanJson);
+  static final com.twitter.zipkin.common.Span localSpanScala =
+      new CodecBenchmarks().readLocalSpan_json_scala();
+  static final byte[] localSpanThrift = Codec.THRIFT.writeSpan(localSpan);
+
+  @Benchmark
+  public Span readLocalSpan_json_java() {
+    return Codec.JSON.readSpan(localSpanJson);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readLocalSpan_json_scala() {
+    return readScalaSpanJson(localSpanJson);
+  }
+
+  @Benchmark
+  public Span readLocalSpan_thrift_java() {
+    return Codec.THRIFT.readSpan(localSpanThrift);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readLocalSpan_thrift_scala() {
+    return readScalaSpanScrooge(localSpanThrift);
+  }
+
+  @Benchmark
+  public byte[] writeLocalSpan_json_java() {
+    return Codec.JSON.writeSpan(localSpan);
+  }
+
+  @Benchmark
+  public byte[] writeLocalSpan_json_scala() throws JsonProcessingException {
+    return writeScalaSpanJson(localSpanScala);
+  }
+
+  @Benchmark
+  public byte[] writeLocalSpan_thrift_java() {
+    return Codec.THRIFT.writeSpan(localSpan);
+  }
+
+  @Benchmark
+  public byte[] writeLocalSpan_thrift_scala() {
+    return writeScalaSpanScrooge(localSpanScala);
+  }
+
+  static final byte[] clientSpanJson = read("/span-client.json");
+  static final Span clientSpan = Codec.JSON.readSpan(clientSpanJson);
+  static final com.twitter.zipkin.common.Span clientSpanScala =
+      new CodecBenchmarks().readClientSpan_json_scala();
+  static final byte[] clientSpanThrift = Codec.THRIFT.writeSpan(clientSpan);
+
+  @Benchmark
+  public Span readClientSpan_json_java() {
+    return Codec.JSON.readSpan(clientSpanJson);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readClientSpan_json_scala() {
+    return readScalaSpanJson(clientSpanJson);
+  }
+
+  @Benchmark
+  public Span readClientSpan_thrift_java() {
+    return Codec.THRIFT.readSpan(clientSpanThrift);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readClientSpan_thrift_scala() {
+    return readScalaSpanScrooge(clientSpanThrift);
+  }
+
+  @Benchmark
+  public byte[] writeClientSpan_json_java() {
+    return Codec.JSON.writeSpan(clientSpan);
+  }
+
+  @Benchmark
+  public byte[] writeClientSpan_json_scala() throws JsonProcessingException {
+    return writeScalaSpanJson(clientSpanScala);
+  }
+
+  @Benchmark
+  public byte[] writeClientSpan_thrift_java() {
+    return Codec.THRIFT.writeSpan(clientSpan);
+  }
+
+  @Benchmark
+  public byte[] writeClientSpan_thrift_scala() {
+    return writeScalaSpanScrooge(clientSpanScala);
+  }
+
+  static final byte[] rpcSpanJson = read("/span-client.json");
+  static final Span rpcSpan = Codec.JSON.readSpan(rpcSpanJson);
+  static final com.twitter.zipkin.common.Span rpcSpanScala =
+      new CodecBenchmarks().readRpcSpan_json_scala();
+  static final byte[] rpcSpanThrift = Codec.THRIFT.writeSpan(rpcSpan);
+
+  @Benchmark
+  public Span readRpcSpan_json_java() {
+    return Codec.JSON.readSpan(rpcSpanJson);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readRpcSpan_json_scala() {
+    return readScalaSpanJson(rpcSpanJson);
+  }
+
+  @Benchmark
+  public Span readRpcSpan_thrift_java() {
+    return Codec.THRIFT.readSpan(rpcSpanThrift);
+  }
+
+  @Benchmark
+  public com.twitter.zipkin.common.Span readRpcSpan_thrift_scala() {
+    return readScalaSpanScrooge(rpcSpanThrift);
+  }
+
+  @Benchmark
+  public byte[] writeRpcSpan_json_java() {
+    return Codec.JSON.writeSpan(rpcSpan);
+  }
+
+  @Benchmark
+  public byte[] writeRpcSpan_json_scala() throws JsonProcessingException {
+    return writeScalaSpanJson(rpcSpanScala);
+  }
+
+  @Benchmark
+  public byte[] writeRpcSpan_thrift_java() {
+    return Codec.THRIFT.writeSpan(rpcSpan);
+  }
+
+  @Benchmark
+  public byte[] writeRpcSpan_thrift_scala() {
+    return writeScalaSpanScrooge(rpcSpanScala);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + CodecBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  /** In the scala impl, there's conversion between the json model and the one used in code. */
+  static com.twitter.zipkin.common.Span readScalaSpanJson(byte[] json) {
+    try {
+      return JsonSpan$.MODULE$.invert(json_scalaReader.<JsonSpan>readValue(json));
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  byte[] writeScalaSpanJson(com.twitter.zipkin.common.Span span) throws JsonProcessingException {
+    return json_scalaWriter.writeValueAsBytes(JsonSpan$.MODULE$.apply(span));
+  }
+
+  /** In the scala impl, there's conversion between the thrift model and the one used in code. */
+  static com.twitter.zipkin.common.Span readScalaSpanScrooge(byte[] thrift) {
+    return thrift$.MODULE$.thriftSpanToSpan(
+        Span$.MODULE$.decode(new TBinaryProtocol(new TMemoryInputTransport(thrift)))
+    ).toSpan();
+  }
+
+  static byte[] writeScalaSpanScrooge(com.twitter.zipkin.common.Span span) {
+    TTransport transport = new TMemoryBuffer(32);
+    thrift$.MODULE$.spanToThriftSpan(span).toThrift().write(new TBinaryProtocol(transport));
+    return transport.getBuffer();
+  }
+
+  static byte[] read(String resource) {
+    try {
+      return ByteStreams.toByteArray(CodecBenchmarks.class.getResourceAsStream(resource));
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/benchmarks/src/main/resources/span-client.json
+++ b/benchmarks/src/main/resources/span-client.json
@@ -1,0 +1,48 @@
+{
+  "traceId": "5af7183fb1d4cf5f",
+  "name": "query",
+  "id": "352bff9a74ca9ad2",
+  "parentId": "6b221d5bc9e6496c",
+  "timestamp": 1461750040359000,
+  "duration": 5000,
+  "annotations": [
+    {
+      "endpoint": {
+        "serviceName": "zipkin-server",
+        "ipv4": "172.19.0.3",
+        "port": 9411
+      },
+      "timestamp": 1461750040359000,
+      "value": "cs"
+    },
+    {
+      "endpoint": {
+        "serviceName": "zipkin-server",
+        "ipv4": "172.19.0.3",
+        "port": 9411
+      },
+      "timestamp": 1461750040364000,
+      "value": "cr"
+    }
+  ],
+  "binaryAnnotations": [
+    {
+      "key": "jdbc.query",
+      "value": "select distinct `zipkin_spans`.`trace_id` from `zipkin_spans` join `zipkin_annotations` on (`zipkin_spans`.`trace_id` = `zipkin_annotations`.`trace_id` and `zipkin_spans`.`id` = `zipkin_annotations`.`span_id`) where (`zipkin_annotations`.`endpoint_service_name` = ? and `zipkin_spans`.`start_ts` between ? and ?) order by `zipkin_spans`.`start_ts` desc limit ?",
+      "endpoint": {
+        "serviceName": "zipkin-server",
+        "ipv4": "172.19.0.3",
+        "port": 9411
+      }
+    },
+    {
+      "key": "sa",
+      "value": true,
+      "endpoint": {
+        "serviceName": "mysql",
+        "ipv4": "172.19.0.2",
+        "port": 3306
+      }
+    }
+  ]
+}

--- a/benchmarks/src/main/resources/span-local.json
+++ b/benchmarks/src/main/resources/span-local.json
@@ -1,0 +1,29 @@
+{
+  "traceId": "5af7183fb1d4cf5f",
+  "name": "get-traces",
+  "id": "6b221d5bc9e6496c",
+  "parentId": "5af7183fb1d4cf5f",
+  "timestamp": 1461750040358000,
+  "duration": 15495,
+  "annotations": [],
+  "binaryAnnotations": [
+    {
+      "key": "lc",
+      "value": "JDBCSpanStore",
+      "endpoint": {
+        "serviceName": "zipkin-server",
+        "ipv4": "172.19.0.3",
+        "port": 9411
+      }
+    },
+    {
+      "key": "request",
+      "value": "QueryRequest{serviceName=zipkin-server, spanName=null, annotations=[], binaryAnnotations={}, minDuration=null, maxDuration=null, endTs=1461750033209, lookback=604800000, limit=10}",
+      "endpoint": {
+        "serviceName": "zipkin-server",
+        "ipv4": "172.19.0.3",
+        "port": 9411
+      }
+    }
+  ]
+}

--- a/benchmarks/src/main/resources/span-rpc.json
+++ b/benchmarks/src/main/resources/span-rpc.json
@@ -1,0 +1,130 @@
+{
+  "traceId": "83c138a4ee0f3de9",
+  "name": "get",
+  "id": "d673d7abe80d2f3f",
+  "parentId": "83c138a4ee0f3de9",
+  "timestamp": 1461750491274000,
+  "duration": 51000,
+  "annotations": [
+    {
+      "timestamp": 1461750491274000,
+      "value": "cs",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "timestamp": 1461750491274000,
+      "value": "ws",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "timestamp": 1461750491298000,
+      "value": "sr",
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "172.18.0.4",
+        "port": 9411
+      }
+    },
+    {
+      "timestamp": 1461750491302000,
+      "value": "ss",
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "172.18.0.4",
+        "port": 9411
+      }
+    },
+    {
+      "timestamp": 1461750491325000,
+      "value": "cr",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "timestamp": 1461750491325000,
+      "value": "wr",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    }
+  ],
+  "binaryAnnotations": [
+    {
+      "key": "http.path",
+      "value": "/api/v1/traces",
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "key": "srv/finagle.version",
+      "value": "6.34.0",
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "key": "sa",
+      "value": true,
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "172.18.0.4",
+        "port": 9411
+      }
+    },
+    {
+      "key": "ca",
+      "value": true,
+      "endpoint": {
+        "serviceName": "zipkin-query",
+        "ipv4": "172.18.0.3",
+        "port": 42291
+      }
+    },
+    {
+      "key": "http.uri",
+      "value": "/api/v1/traces",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "key": "clnt/finagle.version",
+      "value": "6.34.0",
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "127.0.0.1"
+      }
+    },
+    {
+      "key": "sa",
+      "value": true,
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "172.18.0.4",
+        "port": 9411
+      }
+    },
+    {
+      "key": "ca",
+      "value": true,
+      "endpoint": {
+        "serviceName": "zipkin-web",
+        "ipv4": "172.18.0.3",
+        "port": 42291
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <moshi.version>1.1.0</moshi.version>
-    <okio.version>1.6.0</okio.version>
+    <okio.version>1.7.0</okio.version>
     <spring-boot.version>1.3.3.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -32,6 +32,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
     </dependency>

--- a/zipkin/src/main/java/zipkin/internal/Util.java
+++ b/zipkin/src/main/java/zipkin/internal/Util.java
@@ -15,7 +15,7 @@ package zipkin.internal;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -65,11 +65,12 @@ public final class Util {
     return reference;
   }
 
-  public static <T extends Comparable<? super T>> List<T> sortedList(@Nullable Collection<T> input) {
-    if (input == null || input.isEmpty()) return Collections.emptyList();
-    if (input.size() == 1) return Collections.singletonList(input.iterator().next());
-    List<T> result = new ArrayList<>(input);
-    Collections.sort(result);
+  public static <T extends Comparable<? super T>> List<T> sortedList(@Nullable Collection<T> in) {
+    if (in == null || in.isEmpty()) return Collections.emptyList();
+    if (in.size() == 1) return Collections.singletonList(in.iterator().next());
+    Object[] array = in.toArray();
+    Arrays.sort(array);
+    List result = Arrays.asList(array);
     return Collections.unmodifiableList(result);
   }
 


### PR DESCRIPTION
This adds benchmarks around codecs, mainly to ensure the bundled
`zipkin.Codec` is competitive.

Here are the results from my macbook

```
Benchmark                                      Mode  Cnt     Score    Error   Units
CodecBenchmarks.readClientSpan_json_java      thrpt   15   100.003 ±  2.292  ops/ms
CodecBenchmarks.readClientSpan_json_scala     thrpt   15   134.154 ±  3.692  ops/ms
CodecBenchmarks.readClientSpan_thrift_java    thrpt   15   525.387 ± 20.644  ops/ms
CodecBenchmarks.readClientSpan_thrift_scala   thrpt   15   512.669 ± 16.775  ops/ms
CodecBenchmarks.readLocalSpan_json_java       thrpt   15   164.572 ±  1.836  ops/ms
CodecBenchmarks.readLocalSpan_json_scala      thrpt   15   208.522 ±  6.956  ops/ms
CodecBenchmarks.readLocalSpan_thrift_java     thrpt   15   915.019 ± 17.520  ops/ms
CodecBenchmarks.readLocalSpan_thrift_scala    thrpt   15   823.876 ± 30.361  ops/ms
CodecBenchmarks.readRpcSpan_json_java         thrpt   15   104.246 ±  3.192  ops/ms
CodecBenchmarks.readRpcSpan_json_scala        thrpt   15   136.006 ±  6.189  ops/ms
CodecBenchmarks.readRpcSpan_thrift_java       thrpt   15   554.198 ± 18.342  ops/ms
CodecBenchmarks.readRpcSpan_thrift_scala      thrpt   15   516.459 ± 17.000  ops/ms
CodecBenchmarks.writeClientSpan_json_java     thrpt   15    96.862 ±  2.197  ops/ms
CodecBenchmarks.writeClientSpan_json_scala    thrpt   15    81.060 ±  1.511  ops/ms
CodecBenchmarks.writeClientSpan_thrift_java   thrpt   15   983.262 ± 22.960  ops/ms
CodecBenchmarks.writeClientSpan_thrift_scala  thrpt   15   414.633 ±  7.959  ops/ms
CodecBenchmarks.writeLocalSpan_json_java      thrpt   15   158.420 ±  1.820  ops/ms
CodecBenchmarks.writeLocalSpan_json_scala     thrpt   15   129.593 ±  2.831  ops/ms
CodecBenchmarks.writeLocalSpan_thrift_java    thrpt   15  1553.434 ± 55.679  ops/ms
CodecBenchmarks.writeLocalSpan_thrift_scala   thrpt   15   647.828 ±  8.234  ops/ms
CodecBenchmarks.writeRpcSpan_json_java        thrpt   15    96.656 ±  2.825  ops/ms
CodecBenchmarks.writeRpcSpan_json_scala       thrpt   15    80.936 ±  2.409  ops/ms
CodecBenchmarks.writeRpcSpan_thrift_java      thrpt   15   986.985 ± 36.345  ops/ms
CodecBenchmarks.writeRpcSpan_thrift_scala     thrpt   15   421.857 ± 10.761  ops/ms
```