### PR TITLE
Splits instrumentation sampling from collector sampling

### DIFF
--- a/benchmarks/src/main/java/zipkin/benchmarks/SamplerBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/benchmarks/SamplerBenchmarks.java
@@ -31,7 +31,9 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import zipkin.Sampler;
+import zipkin.BoundaryTraceIdSampler;
+import zipkin.CountingTraceIdSampler;
+import zipkin.TraceIdSampler;
 
 /**
  * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
@@ -83,14 +85,26 @@ public class SamplerBenchmarks {
   }
 
   /**
-   * This measures the trace id sampler provided with zipkin-java
+   * This measures the boundary trace id sampler provided with zipkin-java
    */
   @Benchmark
-  public boolean traceIdSampler(Args args) {
-    return TRACE_ID_SAMPLER.isSampled(args.traceId);
+  public boolean traceIdSampler_boundary(Args args) {
+    return TRACE_ID_SAMPLER_BOUNDARY.isSampled(args.traceId);
   }
 
-  static final Sampler TRACE_ID_SAMPLER = Sampler.create(SAMPLE_RATE);
+  static final TraceIdSampler TRACE_ID_SAMPLER_BOUNDARY =
+      BoundaryTraceIdSampler.create(SAMPLE_RATE);
+
+  /**
+   * This measures the counting trace id sampler provided with zipkin-java
+   */
+  @Benchmark
+  public boolean traceIdSampler_counting(Args args) {
+    return TRACE_ID_SAMPLER_COUNTING.isSampled(args.traceId);
+  }
+
+  static final TraceIdSampler TRACE_ID_SAMPLER_COUNTING =
+      CountingTraceIdSampler.create(0.01f); // doesn't take high-precision
 
   /**
    * Zipkin collector's AdjustableGlobalSampler compares the absolute value of the trace id against

--- a/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -36,7 +36,7 @@ import scala.runtime.BoxedUnit;
 import zipkin.AsyncSpanConsumer;
 import zipkin.AsyncSpanStore;
 import zipkin.Codec;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.StorageComponent;
 import zipkin.internal.Nullable;
 
@@ -55,7 +55,7 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
 
   public ScalaSpanStoreAdapter(StorageComponent storage) {
     this.spanStore = storage.asyncSpanStore();
-    this.spanConsumer = storage.asyncSpanConsumer(Sampler.ALWAYS_SAMPLE);
+    this.spanConsumer = storage.asyncSpanConsumer(CollectorSampler.ALWAYS_SAMPLE);
   }
 
   @Override

--- a/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
+++ b/zipkin-junit/src/main/java/zipkin/junit/ZipkinDispatcher.java
@@ -26,7 +26,7 @@ import zipkin.Codec;
 import zipkin.DependencyLink;
 import zipkin.InMemoryStorage;
 import zipkin.QueryRequest;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.Span;
 import zipkin.SpanStore;
 import zipkin.internal.SpanConsumerLogger;
@@ -41,7 +41,7 @@ final class ZipkinDispatcher extends Dispatcher {
 
   ZipkinDispatcher(InMemoryStorage storage, MockWebServer server) {
     this.store = storage.spanStore();
-    this.consumer = storage.asyncSpanConsumer(Sampler.ALWAYS_SAMPLE);
+    this.consumer = storage.asyncSpanConsumer(CollectorSampler.ALWAYS_SAMPLE);
     this.server = server;
   }
 

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
@@ -18,7 +18,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import zipkin.AsyncSpanConsumer;
 import zipkin.AsyncSpanStore;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.SpanStore;
 import zipkin.StorageComponent;
 
@@ -59,7 +59,7 @@ final class HttpStorage implements StorageComponent {
     return asyncSpanStore;
   }
 
-  @Override public AsyncSpanConsumer asyncSpanConsumer(Sampler sampler) {
+  @Override public AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler) {
     return makeSampled(consumer, checkNotNull(sampler, "sampler"));
   }
 

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculatorInput.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateCalculatorInput.java
@@ -37,7 +37,7 @@ final class SampleRateCalculatorInput
   private final int requiredOutliers;
   private final ArrayDeque<Map<String, Integer>> buffer;
 
-  SampleRateCalculatorInput(ZooKeeperSampler.Builder builder, AtomicInteger target) {
+  SampleRateCalculatorInput(ZooKeeperCollectorSampler.Builder builder, AtomicInteger target) {
     this.target = target;
     this.measurementsInWindow = builder.windowSize / builder.updateFrequency;
     this.sufficientThreshold = builder.sufficientWindowSize / builder.updateFrequency;

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdateGuard.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/SampleRateUpdateGuard.java
@@ -21,7 +21,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin.sampler.zookeeper.ZooKeeperSampler.Builder;
+import zipkin.sampler.zookeeper.ZooKeeperCollectorSampler.Builder;
 
 /**
  * Allows an update while a leader, but not more often than {@link Builder#updateFrequency(int)}

--- a/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSampler.java
+++ b/zipkin-samplers/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSampler.java
@@ -30,7 +30,7 @@ import org.apache.curator.framework.recipes.cache.NodeCache;
 import org.apache.curator.framework.recipes.nodes.GroupMember;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.Span;
 import zipkin.internal.Util;
 
@@ -60,8 +60,8 @@ import static zipkin.internal.Util.checkNotNull;
  * <p>Algorithms and defaults are tuned to favor decreasing the sample rate vs increasing it. For
  * example, a surge in writes will fire a rate adjustment faster than a drop in writes.
  */
-public final class ZooKeeperSampler extends Sampler implements Closeable {
-  final static Logger log = LoggerFactory.getLogger(ZooKeeperSampler.class);
+public final class ZooKeeperCollectorSampler extends CollectorSampler implements Closeable {
+  final static Logger log = LoggerFactory.getLogger(ZooKeeperCollectorSampler.class);
 
   public static final class Builder {
     float initialRate = 1.0f;
@@ -125,10 +125,10 @@ public final class ZooKeeperSampler extends Sampler implements Closeable {
     /**
      * @param client must be started, and will not be closed on {@link #close()}
      */
-    public ZooKeeperSampler build(CuratorFramework client) {
+    public ZooKeeperCollectorSampler build(CuratorFramework client) {
       checkState(checkNotNull(client, "client").getState() == CuratorFrameworkState.STARTED,
           "%s is not started", client.getState());
-      return new ZooKeeperSampler(this, client);
+      return new ZooKeeperCollectorSampler(this, client);
     }
   }
 
@@ -138,7 +138,7 @@ public final class ZooKeeperSampler extends Sampler implements Closeable {
   final AtomicInteger storeRate;
   final Closer closer = Closer.create();
 
-  ZooKeeperSampler(Builder builder, CuratorFramework client) {
+  ZooKeeperCollectorSampler(Builder builder, CuratorFramework client) {
     groupMember = builder.id;
     boundary =
         new AtomicLong((long) (Long.MAX_VALUE * builder.initialRate)); // safe cast as less <= 1

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorInputTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateCalculatorInputTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SampleRateCalculatorInputTest {
 
   @Test public void presentWhenTargetIsPositive() {
-    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperCollectorSampler.Builder()
         .windowSize(1)
         .updateFrequency(1)
         .sufficientWindowSize(1)
@@ -39,7 +39,7 @@ public class SampleRateCalculatorInputTest {
   }
 
   @Test public void emptyWhenInsufficientData() {
-    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperCollectorSampler.Builder()
         .windowSize(3)
         .sufficientWindowSize(2)
         .updateFrequency(1)
@@ -56,7 +56,7 @@ public class SampleRateCalculatorInputTest {
   }
 
   @Test public void emptyWhenElementIsNotPositive() {
-    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperCollectorSampler.Builder()
         .windowSize(1)
         .updateFrequency(1)
         .sufficientWindowSize(1)
@@ -73,7 +73,7 @@ public class SampleRateCalculatorInputTest {
   }
 
   @Test public void emptyUntilEnoughOutliers() {
-    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperSampler.Builder()
+    SampleRateCalculatorInput rates = new SampleRateCalculatorInput(new ZooKeeperCollectorSampler.Builder()
         .windowSize(3)
         .sufficientWindowSize(1)
         .updateFrequency(1)

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdateGuardTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/SampleRateUpdateGuardTest.java
@@ -39,15 +39,15 @@ public class SampleRateUpdateGuardTest {
 
   @Test
   public void idempotentClose() throws Exception {
-    SampleRateUpdateGuard guard = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard = guard(new ZooKeeperCollectorSampler.Builder());
     guard.close();
     guard.close();
   }
 
   @Test
   public void passesWhenALeader() throws Exception {
-    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
-    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperCollectorSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperCollectorSampler.Builder());
 
     waitForALeader(guard1, guard2);
 
@@ -61,8 +61,8 @@ public class SampleRateUpdateGuardTest {
 
   @Test
   public void onlyPassesOncePerInterval() throws Exception {
-    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder().updateFrequency(1));
-    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder().updateFrequency(1));
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperCollectorSampler.Builder().updateFrequency(1));
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperCollectorSampler.Builder().updateFrequency(1));
 
     waitForALeader(guard1, guard2);
 
@@ -82,8 +82,8 @@ public class SampleRateUpdateGuardTest {
 
   @Test
   public void shouldElectOnlyOneLeader() throws Exception {
-    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
-    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperCollectorSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperCollectorSampler.Builder());
 
     waitForALeader(guard1, guard2);
 
@@ -94,8 +94,8 @@ public class SampleRateUpdateGuardTest {
 
   @Test
   public void shouldStillBeOneLeaderAfterZKFailure() throws Exception {
-    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
-    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperCollectorSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperCollectorSampler.Builder());
 
     waitForALeader(guard1, guard2);
 
@@ -114,8 +114,8 @@ public class SampleRateUpdateGuardTest {
 
   @Test
   public void electsNewLeaderOnClose() throws Exception {
-    SampleRateUpdateGuard guard1 = guard(new ZooKeeperSampler.Builder());
-    SampleRateUpdateGuard guard2 = guard(new ZooKeeperSampler.Builder());
+    SampleRateUpdateGuard guard1 = guard(new ZooKeeperCollectorSampler.Builder());
+    SampleRateUpdateGuard guard2 = guard(new ZooKeeperCollectorSampler.Builder());
 
     waitForALeader(guard1, guard2);
 
@@ -137,7 +137,7 @@ public class SampleRateUpdateGuardTest {
 
   int count = 0;
 
-  SampleRateUpdateGuard guard(ZooKeeperSampler.Builder builder) {
+  SampleRateUpdateGuard guard(ZooKeeperCollectorSampler.Builder builder) {
     builder.id("guard-" + count++);
     return closer.register(new SampleRateUpdateGuard(zookeeper.client, builder));
   }

--- a/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSamplerTest.java
+++ b/zipkin-samplers/zookeeper/src/test/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSamplerTest.java
@@ -28,18 +28,18 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withinPercentage;
 
-public class ZooKeeperSamplerTest {
-  static final String PREFIX = "/" + ZooKeeperSamplerTest.class.getSimpleName();
+public class ZooKeeperCollectorSamplerTest {
+  static final String PREFIX = "/" + ZooKeeperCollectorSamplerTest.class.getSimpleName();
   @Rule public ZooKeeperRule zookeeper = new ZooKeeperRule();
 
   InMemoryStorage storage = new InMemoryStorage();
-  ZooKeeperSampler sampler;
+  ZooKeeperCollectorSampler sampler;
 
   @Before public void clear() throws Exception {
     if (sampler != null) {
       sampler.close();
     }
-    sampler = new ZooKeeperSampler.Builder()
+    sampler = new ZooKeeperCollectorSampler.Builder()
         .basePath(PREFIX)
         .updateFrequency(1) // least possible value
         .build(zookeeper.client);

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHttpCollector.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import zipkin.AsyncSpanConsumer;
 import zipkin.Codec;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.Span;
 import zipkin.StorageComponent;
 import zipkin.internal.SpanConsumerLogger;
@@ -50,7 +50,7 @@ public class ZipkinHttpCollector {
 
   /** lazy so transient storage errors don't crash bootstrap */
   @Lazy
-  @Autowired ZipkinHttpCollector(StorageComponent storage, Sampler sampler,
+  @Autowired ZipkinHttpCollector(StorageComponent storage, CollectorSampler sampler,
       Codec.Factory codecFactory) {
     this.consumer = storage.asyncSpanConsumer(sampler);
     this.jsonCodec = checkNotNull(codecFactory.get(APPLICATION_JSON_VALUE), APPLICATION_JSON_VALUE);

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
@@ -40,8 +40,8 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import zipkin.Codec;
+import zipkin.CollectorSampler;
 import zipkin.InMemoryStorage;
-import zipkin.Sampler;
 import zipkin.SpanStore;
 import zipkin.StorageComponent;
 import zipkin.cassandra.CassandraStorage;
@@ -61,9 +61,9 @@ public class ZipkinServerConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean(Sampler.class)
-  Sampler traceIdSampler(@Value("${zipkin.collector.sample-rate:1.0}") float rate) {
-    return Sampler.create(rate);
+  @ConditionalOnMissingBean(CollectorSampler.class)
+  CollectorSampler traceIdSampler(@Value("${zipkin.collector.sample-rate:1.0}") float rate) {
+    return CollectorSampler.create(rate);
   }
 
   /**
@@ -195,7 +195,7 @@ public class ZipkinServerConfiguration {
   @EnableConfigurationProperties(ZipkinScribeProperties.class)
   @ConditionalOnClass(name = "zipkin.scribe.ScribeCollector")
   static class ScribeConfiguration {
-    @Bean ScribeCollector scribe(ZipkinScribeProperties scribe, Sampler sampler,
+    @Bean ScribeCollector scribe(ZipkinScribeProperties scribe, CollectorSampler sampler,
         StorageComponent storage) {
       return new ScribeCollector.Builder()
           .category(scribe.getCategory())
@@ -211,7 +211,7 @@ public class ZipkinServerConfiguration {
   @EnableConfigurationProperties(ZipkinKafkaProperties.class)
   @ConditionalOnKafkaZookeeper
   static class KafkaConfiguration {
-    @Bean KafkaCollector kafka(ZipkinKafkaProperties kafka, Sampler sampler,
+    @Bean KafkaCollector kafka(ZipkinKafkaProperties kafka, CollectorSampler sampler,
         StorageComponent storage) {
       return new KafkaCollector.Builder()
           .topic(kafka.getTopic())

--- a/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/SpanStoreSpanCollector.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import zipkin.AsyncSpanConsumer;
 import zipkin.Codec;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.Span;
 import zipkin.SpanStore;
 import zipkin.StorageComponent;
@@ -47,6 +47,6 @@ public class SpanStoreSpanCollector extends AbstractSpanCollector {
   @Override
   protected void sendSpans(byte[] json) throws IOException {
     List<Span> spans = Codec.JSON.readSpans(json);
-    storage.asyncSpanConsumer(Sampler.ALWAYS_SAMPLE).accept(spans, AsyncSpanConsumer.NOOP_CALLBACK);
+    storage.asyncSpanConsumer(CollectorSampler.ALWAYS_SAMPLE).accept(spans, AsyncSpanConsumer.NOOP_CALLBACK);
   }
 }

--- a/zipkin-storage/guava/src/main/java/zipkin/spanstore/guava/GuavaStorageComponent.java
+++ b/zipkin-storage/guava/src/main/java/zipkin/spanstore/guava/GuavaStorageComponent.java
@@ -15,7 +15,7 @@ package zipkin.spanstore.guava;
 
 import zipkin.AsyncSpanConsumer;
 import zipkin.AsyncSpanStore;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.SpanStore;
 import zipkin.StorageComponent;
 
@@ -36,7 +36,7 @@ public abstract class GuavaStorageComponent implements StorageComponent {
 
   public abstract GuavaSpanStore guavaSpanStore();
 
-  @Override public AsyncSpanConsumer asyncSpanConsumer(Sampler sampler) {
+  @Override public AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler) {
     return makeSampled(guavaToAsync(guavaSpanConsumer()), checkNotNull(sampler, "sampler"));
   }
 

--- a/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCStorage.java
+++ b/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCStorage.java
@@ -21,7 +21,7 @@ import org.jooq.ExecuteListenerProvider;
 import org.jooq.conf.Settings;
 import zipkin.AsyncSpanConsumer;
 import zipkin.AsyncSpanStore;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.SpanStore;
 import zipkin.StorageAdapters.SpanConsumer;
 import zipkin.StorageComponent;
@@ -100,7 +100,7 @@ public final class JDBCStorage implements StorageComponent {
     return spanConsumer;
   }
 
-  @Override public AsyncSpanConsumer asyncSpanConsumer(Sampler sampler) {
+  @Override public AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler) {
     return makeSampled(asyncSpanConsumer, checkNotNull(sampler, "sampler"));
   }
 

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
@@ -22,7 +22,7 @@ import kafka.consumer.ConsumerConfig;
 import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.serializer.StringDecoder;
 import zipkin.AsyncSpanConsumer;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.StorageComponent;
 import zipkin.internal.Lazy;
 
@@ -66,7 +66,7 @@ public final class KafkaCollector implements AutoCloseable {
       return this;
     }
 
-    public KafkaCollector writeTo(StorageComponent storage, Sampler sampler) {
+    public KafkaCollector writeTo(StorageComponent storage, CollectorSampler sampler) {
       checkNotNull(storage, "storage");
       checkNotNull(sampler, "sampler");
       return new KafkaCollector(this, new Lazy<AsyncSpanConsumer>() {

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
@@ -18,7 +18,7 @@ import com.facebook.swift.service.ThriftServer;
 import com.facebook.swift.service.ThriftServerConfig;
 import com.facebook.swift.service.ThriftServiceProcessor;
 import zipkin.AsyncSpanConsumer;
-import zipkin.Sampler;
+import zipkin.CollectorSampler;
 import zipkin.StorageComponent;
 import zipkin.internal.Lazy;
 import zipkin.spanstore.guava.GuavaSpanConsumer;
@@ -50,7 +50,7 @@ public final class ScribeCollector implements AutoCloseable {
       return this;
     }
 
-    public ScribeCollector writeTo(StorageComponent storage, Sampler sampler) {
+    public ScribeCollector writeTo(StorageComponent storage, CollectorSampler sampler) {
       checkNotNull(storage, "storage");
       checkNotNull(sampler, "sampler");
       return new ScribeCollector(this, new Lazy<AsyncSpanConsumer>() {

--- a/zipkin/src/main/java/zipkin/AsyncSpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/AsyncSpanConsumer.java
@@ -36,7 +36,7 @@ public interface AsyncSpanConsumer {
   /**
    * Receives a list of spans {@link Codec#readSpans(byte[]) decoded} from a transport.
    *
-   * @param spans may be subject to a {@link Sampler#isSampled(long) sampling policy}.
+   * @param spans may be subject to a {@link CollectorSampler#isSampled(long) sampling policy}.
    */
   void accept(List<Span> spans, Callback<Void> callback);
 }

--- a/zipkin/src/main/java/zipkin/BoundaryTraceIdSampler.java
+++ b/zipkin/src/main/java/zipkin/BoundaryTraceIdSampler.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import java.util.Random;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for high-traffic instrumentation (ex edge web servers that each
+ * receive >100K requests) who provision random trace ids, and make the sampling decision only once.
+ * It defends against nodes in the cluster selecting exactly the same ids.
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This uses modulo 10000 arithmetic, which allows a minimum sample rate of 0.01%. Trace id
+ * collision was noticed in practice in the Twitter front-end cluster. A random salt is here to
+ * defend against nodes in the same cluster sampling exactly the same subset of trace ids. The goal
+ * was full 64-bit coverage of trace IDs on multi-host deployments.
+ *
+ * <p>Based on https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+ */
+public final class BoundaryTraceIdSampler implements TraceIdSampler {
+  static final long SALT = new Random().nextLong();
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
+   * 0.0001, or 0.01% of traces
+   */
+  public static TraceIdSampler create(float rate) {
+    if (rate == 0) return NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate > 0.0001 && rate < 1, "rate should be between 0.0001 and 1: was %s", rate);
+    final long boundary = (long) (rate * 10000); // safe cast as less <= 1
+    return new BoundaryTraceIdSampler(boundary);
+  }
+
+  private final long boundary;
+
+  BoundaryTraceIdSampler(long boundary) {
+    this.boundary = boundary;
+  }
+
+  /** Returns true when {@code abs(traceId) <= boundary} */
+  @Override
+  public boolean isSampled(long traceId) {
+    long t = Math.abs(traceId ^ SALT);
+    return t % 10000 <= boundary; // Constant expression for readability
+  }
+
+  @Override
+  public String toString() {
+    return "BoundaryTraceIdSampler(" + boundary + ")";
+  }
+}

--- a/zipkin/src/main/java/zipkin/CountingTraceIdSampler.java
+++ b/zipkin/src/main/java/zipkin/CountingTraceIdSampler.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
+ * requests), or those who do not provision random trace ids. It not appropriate for collectors as
+ * the sampling decision isn't idempotent (consistent based on trace id).
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This counts to see how many out of 100 traces should be retained. This means that it is
+ * accurate in units of 100 traces.
+ */
+public final class CountingTraceIdSampler implements TraceIdSampler {
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
+   * 0.0001, or 0.01% of traces
+   */
+  public static TraceIdSampler create(final float rate) {
+    if (rate == 0) return NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate >= 0.01f && rate < 1.0f, "rate should be between 0.01 and 1: was %s", rate);
+    return new CountingTraceIdSampler(rate);
+  }
+
+  private final int outOf100;
+
+  private int i = 0;
+  private boolean skipping = false;
+
+  CountingTraceIdSampler(float rate) {
+    this.outOf100 = (int) (rate * 100.0f);
+  }
+
+  @Override
+  public synchronized boolean isSampled(long traceIdIgnored) {
+    boolean result = !skipping;
+    i++;
+    if (i == outOf100) {
+      skipping = true;
+    } else if (i == 100) {
+      i = 0;
+      skipping = false;
+    }
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CountingTraceIdSampler(" + outOf100 + ")";
+  }
+}

--- a/zipkin/src/main/java/zipkin/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin/InMemoryStorage.java
@@ -45,7 +45,7 @@ public final class InMemoryStorage implements StorageComponent {
     return spanStore.spanConsumer;
   }
 
-  @Override public AsyncSpanConsumer asyncSpanConsumer(Sampler sampler) {
+  @Override public AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler) {
     return makeSampled(asyncConsumer, checkNotNull(sampler, "sampler"));
   }
 

--- a/zipkin/src/main/java/zipkin/InternalSamplingAsyncSpanConsumer.java
+++ b/zipkin/src/main/java/zipkin/InternalSamplingAsyncSpanConsumer.java
@@ -20,9 +20,9 @@ import static zipkin.internal.Util.checkNotNull;
 
 final class InternalSamplingAsyncSpanConsumer implements AsyncSpanConsumer {
   final AsyncSpanConsumer asyncConsumer;
-  final Sampler sampler;
+  final CollectorSampler sampler;
 
-  InternalSamplingAsyncSpanConsumer(AsyncSpanConsumer asyncConsumer, Sampler sampler) {
+  InternalSamplingAsyncSpanConsumer(AsyncSpanConsumer asyncConsumer, CollectorSampler sampler) {
     this.asyncConsumer = checkNotNull(asyncConsumer, "asyncConsumer");
     this.sampler = checkNotNull(sampler, "sampler");
   }

--- a/zipkin/src/main/java/zipkin/StorageAdapters.java
+++ b/zipkin/src/main/java/zipkin/StorageAdapters.java
@@ -44,7 +44,7 @@ public final class StorageAdapters {
   }
 
   /** Writes spans to storage, subject to sampling policy. */
-  public static AsyncSpanConsumer makeSampled(AsyncSpanConsumer delegate, Sampler sampler) {
+  public static AsyncSpanConsumer makeSampled(AsyncSpanConsumer delegate, CollectorSampler sampler) {
     if (delegate instanceof InternalSamplingAsyncSpanConsumer) return delegate;
     return new InternalSamplingAsyncSpanConsumer(delegate, sampler);
   }

--- a/zipkin/src/main/java/zipkin/StorageComponent.java
+++ b/zipkin/src/main/java/zipkin/StorageComponent.java
@@ -32,7 +32,7 @@ public interface StorageComponent extends AutoCloseable {
    * Used to store spans received on a transport such as Kafka. The provided consumer will retain
    * spans according to the sampler's policy.
    */
-  AsyncSpanConsumer asyncSpanConsumer(Sampler sampler);
+  AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler);
 
   /**
    * Closes any network resources created implicitly by the component.

--- a/zipkin/src/main/java/zipkin/TraceIdSampler.java
+++ b/zipkin/src/main/java/zipkin/TraceIdSampler.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+/**
+ * TraceIdSampler decides if a particular trace ID should be "sampled".
+ *
+ * <p>For instrumentation, this decides whether the overhead of tracing will occur and/or if a trace
+ * will be reported to the collection tier. The instrumentation sampling decision happens once, at
+ * the root of the trace, and is propagated downstream. For this reason, the decision needn't be
+ * consistent based on trace ID.
+ *
+ * <p>For collectors, this is a major input to the decision of whether a trace will be written to
+ * storage. Unlike instrumentation, collector's tracing decision needs to be consistent across
+ * nodes. For this reason, the implementation must be consistent on trace ID.
+ */
+public interface TraceIdSampler {
+  TraceIdSampler ALWAYS_SAMPLE = new TraceIdSampler() {
+    @Override public boolean isSampled(long traceId) {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "AlwaysSample";
+    }
+  };
+
+  TraceIdSampler NEVER_SAMPLE = new TraceIdSampler() {
+    @Override public boolean isSampled(long traceId) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "NeverSample";
+    }
+  };
+
+  /**
+   * Returns true if a trace should be measured.
+   *
+   * <p>Zipkin v1 instrumentation uses before-the-fact sampling. This means that the decision to
+   * keep or drop the trace is made before any work is measured, or annotations are added. As such,
+   * the input parameter to zipkin v1 samplers is the trace ID (64-bit random number).
+   */
+  boolean isSampled(long traceId);
+}

--- a/zipkin/src/test/java/zipkin/BoundaryTraceIdSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/BoundaryTraceIdSamplerTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class BoundaryTraceIdSamplerTest extends TraceIdSamplerTest {
+  @Override TraceIdSampler newSampler(float rate) {
+    return BoundaryTraceIdSampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(4);
+  }
+}

--- a/zipkin/src/test/java/zipkin/CountingTraceIdSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/CountingTraceIdSamplerTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class CountingTraceIdSamplerTest extends TraceIdSamplerTest {
+  @Override TraceIdSampler newSampler(float rate) {
+    return CountingTraceIdSampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(0);
+  }
+}

--- a/zipkin/src/test/java/zipkin/DependenciesTest.java
+++ b/zipkin/src/test/java/zipkin/DependenciesTest.java
@@ -56,7 +56,7 @@ public abstract class DependenciesTest {
   protected void processDependencies(List<Span> spans) {
     // Blocks until the callback completes to allow read-your-writes consistency during tests.
     CallbackCaptor<Void> captor = new CallbackCaptor<>();
-    storage().asyncSpanConsumer(Sampler.ALWAYS_SAMPLE).accept(spans, captor);
+    storage().asyncSpanConsumer(CollectorSampler.ALWAYS_SAMPLE).accept(spans, captor);
     captor.get(); // block on result
   }
 

--- a/zipkin/src/test/java/zipkin/InternalSamplingAsyncSpanConsumerTest.java
+++ b/zipkin/src/test/java/zipkin/InternalSamplingAsyncSpanConsumerTest.java
@@ -22,7 +22,7 @@ public class InternalSamplingAsyncSpanConsumerTest {
 
   InMemorySpanStore store = new InMemorySpanStore();
   AsyncSpanConsumer consumer = StorageAdapters.blockingToAsync(store.spanConsumer, Runnable::run);
-  Sampler never = Sampler.create(0f);
+  CollectorSampler never = CollectorSampler.create(0f);
 
   Span.Builder builder = new Span.Builder()
       .traceId(1234L)

--- a/zipkin/src/test/java/zipkin/SpanStoreTest.java
+++ b/zipkin/src/test/java/zipkin/SpanStoreTest.java
@@ -53,7 +53,7 @@ public abstract class SpanStoreTest {
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
   void accept(Span... spans) {
     CallbackCaptor<Void> captor = new CallbackCaptor<>();
-    storage().asyncSpanConsumer(Sampler.ALWAYS_SAMPLE).accept(asList(spans), captor);
+    storage().asyncSpanConsumer(CollectorSampler.ALWAYS_SAMPLE).accept(asList(spans), captor);
     captor.get(); // block on result
   }
 

--- a/zipkin/src/test/java/zipkin/TestObjects.java
+++ b/zipkin/src/test/java/zipkin/TestObjects.java
@@ -14,6 +14,7 @@
 package zipkin;
 
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import zipkin.internal.ApplyTimestampAndDuration;
 import zipkin.internal.Dependencies;
@@ -73,4 +74,15 @@ public final class TestObjects {
       new DependencyLink.Builder().parent("app").child("db").callCount(1).build()
   );
   public static final Dependencies DEPENDENCIES = Dependencies.create(TODAY, TODAY + 1000, LINKS);
+
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large input to avoid
+   * flaking out due to PRNG nuance.
+   */
+  public static final Span[] LOTS_OF_SPANS =
+      new Random().longs(100000).mapToObj(t -> span(t)).toArray(Span[]::new);
+
+  static Span span(long traceId) {
+    return new Span.Builder().traceId(traceId).id(traceId).name("").build();
+  }
 }

--- a/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import java.util.stream.Stream;
+import org.assertj.core.data.Percentage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.TestObjects.LOTS_OF_SPANS;
+
+@RunWith(Theories.class)
+public abstract class TraceIdSamplerTest {
+  abstract TraceIdSampler newSampler(float rate);
+
+  abstract Percentage expectedErrorRate();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @DataPoints
+  public static final float[] SAMPLE_RATES = {0.01f, 0.5f, 0.9f};
+
+  @Theory
+  public void retainsPerSampleRate(float sampleRate) {
+    TraceIdSampler sampler = newSampler(sampleRate);
+
+    // parallel to ensure there aren't any unsynchronized race conditions
+    long passed = traceIds().parallel().filter(sampler::isSampled).count();
+
+    assertThat(passed)
+        .isCloseTo((long) (LOTS_OF_SPANS.length * sampleRate), expectedErrorRate());
+  }
+
+  @Test
+  public void zeroMeansDropAllTraces() {
+    TraceIdSampler sampler = newSampler(0.0f);
+
+    assertThat(traceIds().filter(sampler::isSampled).findAny())
+        .isEmpty();
+  }
+
+  @Test
+  public void oneMeansKeepAllTraces() {
+    TraceIdSampler sampler = newSampler(1.0f);
+
+    assertThat(traceIds().filter(sampler::isSampled))
+        .hasSize(LOTS_OF_SPANS.length);
+  }
+
+  @Test
+  public void rateCantBeNegative() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(-1.0f);
+  }
+
+  @Test
+  public void rateCantBeOverOne() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(1.1f);
+  }
+
+  Stream<Long> traceIds() {
+    return Stream.of(LOTS_OF_SPANS).map(s -> s.traceId);
+  }
+}


### PR DESCRIPTION
Instrumentation samplers are before-the-fact. When a trace id is
provisioned, a sampler is applied to it to see if tracing should take
place or not. The decision is made once and propagated downstream.

Collector samplers are after-the-fact. When parts of a trace are
received from multiple reporters, they all need to be retained or
dropped consistently.

Before, we were using the same sampler for both sides. This is a
problem in two ways, but mostly for low-traffic sites.

* Low-traffic entry-points will see an unstable sample rate, at worst
dropping all traces. For example, the default RNG in java applied to
the boundary sampler would only get within 3% of the target rate after
100k decisions. Exact precision could be prefered, especially since the
overhead is still less than a microsecond/decision.

* High-traffic entry-points had low-sampling overhead, but they had a
chance of sampling exactly the same trace ids. This would cause two
unrelated requests to show up in the same trace.

This corrects the situation by not sharing a sampling algorithm between
the collectors and the instrumentation. It introduces a counting sampler
which has 100% precision in groups of 100, and a boundary sampler, which
is an order of magnitude faster, but probablistic with a measured 3%
error rate after 100K samples.