### PR TITLE
Doubles performance of CountingTraceIdSampler while increasing precision

### DIFF
--- a/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
@@ -68,6 +68,7 @@ public abstract class TraceIdSamplerTest {
   @Test
   public void rateCantBeNegative() {
     thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("rate should be between 0.0001 and 1: was -1.0");
 
     newSampler(-1.0f);
   }
@@ -75,6 +76,7 @@ public abstract class TraceIdSamplerTest {
   @Test
   public void rateCantBeOverOne() {
     thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("rate should be between 0.0001 and 1: was 1.1");
 
     newSampler(1.1f);
   }


### PR DESCRIPTION
This doubles the performance and increases the precision of the counting
trace ID sampler by using a bitset. After this, both the boundary and
counting sampler support a precision of 0.0001, or 0.01% sample rate.