### PR TITLE
Makes the counting sampler accurate to 100 decisions and more fair

### DIFF
--- a/zipkin/src/main/java/zipkin/CountingTraceIdSampler.java
+++ b/zipkin/src/main/java/zipkin/CountingTraceIdSampler.java
@@ -14,7 +14,7 @@
 package zipkin;
 
 import java.util.BitSet;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Random;
 
 import static zipkin.internal.Util.checkArgument;
 
@@ -25,47 +25,66 @@ import static zipkin.internal.Util.checkArgument;
  *
  * <h3>Implementation</h3>
  *
- * <p>This counts to see how many out of 100 traces should be retained. This means that it is
- * accurate in units of 100 traces.
+ * <p>This initializes a random bitset of size 100 (corresponding to 1% granularity). This means
+ * that it is accurate in units of 100 traces. At runtime, this loops through the bitset, returning
+ * the value according to a counter.
  */
 public final class CountingTraceIdSampler implements TraceIdSampler {
 
   /**
-   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
-   * 0.0001, or 0.01% of traces
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
+   * or 1% of traces
    */
   public static TraceIdSampler create(final float rate) {
     if (rate == 0) return NEVER_SAMPLE;
     if (rate == 1.0) return ALWAYS_SAMPLE;
-    checkArgument(rate >= 0.0001f && rate < 1.0f, "rate should be between 0.0001 and 1: was %s", rate);
+    checkArgument(rate >= 0.01f && rate < 1, "rate should be between 0.01 and 1: was %s", rate);
     return new CountingTraceIdSampler(rate);
   }
 
-  private final AtomicInteger counter = new AtomicInteger(0);
+  private int i; // guarded by this
   private final BitSet sampleDecisions;
 
   /** Fills a bitset with decisions according to the supplied rate. */
   CountingTraceIdSampler(float rate) {
-    int outOf10000 = (int) (rate * 10000.0f);
-    this.sampleDecisions = new BitSet(10000);
-    for (int i = 0; i < outOf10000; i++) {
-      this.sampleDecisions.set(i);
-    }
+    int outOf100 = (int) (rate * 100.0f);
+    this.sampleDecisions = randomBitSet(100, outOf100, new Random());
   }
 
   /** loops over the pre-canned decisions, resetting to zero when it gets to the end. */
   @Override
   public synchronized boolean isSampled(long traceIdIgnored) {
-    final int i = counter.getAndIncrement();
-    boolean result = sampleDecisions.get(i);
-    if (i == 9999) {
-      counter.set(0);
-    }
+    boolean result = sampleDecisions.get(i++);
+    if (i == 100) i = 0;
     return result;
   }
 
   @Override
   public String toString() {
     return "CountingTraceIdSampler()";
+  }
+
+  /**
+   * Reservoir sampling algorithm borrowed from Stack Overflow.
+   *
+   * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+   */
+  static BitSet randomBitSet(int size, int cardinality, Random rnd) {
+    BitSet result = new BitSet(size);
+    int[] chosen = new int[cardinality];
+    int i;
+    for (i = 0; i < cardinality; ++i) {
+      chosen[i] = i;
+      result.set(i);
+    }
+    for (; i < size; ++i) {
+      int j = rnd.nextInt(i + 1);
+      if (j < cardinality) {
+        result.clear(chosen[j]);
+        result.set(i);
+        chosen[j] = i;
+      }
+    }
+    return result;
   }
 }

--- a/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
+++ b/zipkin/src/test/java/zipkin/TraceIdSamplerTest.java
@@ -68,7 +68,6 @@ public abstract class TraceIdSamplerTest {
   @Test
   public void rateCantBeNegative() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("rate should be between 0.0001 and 1: was -1.0");
 
     newSampler(-1.0f);
   }
@@ -76,7 +75,6 @@ public abstract class TraceIdSamplerTest {
   @Test
   public void rateCantBeOverOne() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("rate should be between 0.0001 and 1: was 1.1");
 
     newSampler(1.1f);
   }


### PR DESCRIPTION
Previously, the counting sampler biased the first trace ids. For
example, if you had a sample rate of 50%, 5K traces would be sampled,
then 5K would not be. This would result in a poor experience for low
traffic sites. This randomizes the decisions, so that they are more
fair, and restores the granularity to 100 decisions.