### PR TITLE
Updates to Datastax Cassandra Driver 3.0

### DIFF
--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <cassandra-driver-core.version>2.1.10.1</cassandra-driver-core.version>
+    <cassandra-driver-core.version>3.0.0</cassandra-driver-core.version>
   </properties>
 
   <dependencies>
@@ -41,19 +41,6 @@
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
       <version>${cassandra-driver-core.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.github.jnr</groupId>
-          <artifactId>jnr-posix</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- Above is packaged with 3.0.27, which is licensed under CPL; 3.0.29 is licensed under EPL -->
-    <dependency>
-      <groupId>com.github.jnr</groupId>
-      <artifactId>jnr-posix</artifactId>
-      <version>3.0.29</version>
     </dependency>
 
     <dependency>

--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/internal/ZipkinRetryPolicy.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/internal/ZipkinRetryPolicy.java
@@ -14,9 +14,11 @@
 
 package zipkin.cassandra.internal;
 
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.policies.RetryPolicy;
 
 /** This class was copied from org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy */
@@ -43,5 +45,21 @@ public final class ZipkinRetryPolicy implements RetryPolicy {
   public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica,
       int aliveReplica, int nbRetry) {
     return RetryDecision.retry(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public RetryDecision onRequestError(Statement statement, ConsistencyLevel cl,
+      DriverException e, int nbRetry) {
+    return RetryDecision.tryNextHost(ConsistencyLevel.ONE);
+  }
+
+  @Override
+  public void init(Cluster cluster) {
+    // nothing to do
+  }
+
+  @Override
+  public void close() {
+    // nothing to do
   }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/ClusterProviderTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/ClusterProviderTest.java
@@ -105,7 +105,7 @@ public class ClusterProviderTest {
 
     Authenticator authenticator =
         cluster.get().getConfiguration().getProtocolOptions().getAuthProvider()
-            .newAuthenticator(new InetSocketAddress("localhost", 8080));
+            .newAuthenticator(new InetSocketAddress("localhost", 8080), null);
 
     byte[] SASLhandshake = {0, 'b', 'o', 'b', 0, 's', 'e', 'c', 'r', 'e', 't'};
     assertThat(authenticator.initialResponse())


### PR DESCRIPTION
By updating to Datastax Driver 3, we still support Cassandra 2.2+, but
also 3.0.

Tested against Cassandra 2.2, 3.0 and 3.5

Fixes #183