### PR TITLE
Makes max message size configurable in Kafka

### DIFF
--- a/zipkin-server/README.md
+++ b/zipkin-server/README.md
@@ -117,12 +117,20 @@ The Scribe collector is enabled by default, configured by the following:
     * `COLLECTOR_PORT`: Listen port for the scribe thrift api; Defaults to 9410
 
 ### Kafka Collector
+This collector remains a Kafka 0.8.x consumer, while Zipkin systems update to 0.9+.
+
 The following apply when `KAFKA_ZOOKEEPER` is set:
 
-    * `KAFKA_ZOOKEEPER`: ZooKeeper host string, comma-separated host:port value. no default.
-    * `KAFKA_TOPIC`: Defaults to zipkin
-    * `KAFKA_GROUP_ID`: Consumer group this process is consuming on behalf of. Defaults to zipkin
-    * `KAFKA_STREAMS`: Count of consumer threads consuming the topic. defaults to 1.
+    * `KAFKA_TOPIC`: Topic zipkin spans will be consumed from. Defaults to "zipkin"
+    * `KAFKA_STREAMS`: Count of threads/streams consuming the topic. Defaults to 1
+
+Settings below correspond to "Old Consumer Configs" in [Kafka documentation](http://kafka.apache.org/documentation.html)
+
+Variable | Old Consumer Config | Description
+--- | --- | ---
+KAFKA_ZOOKEEPER | zookeeper.connect | The zookeeper connect string, ex. 127.0.0.1:2181. No default
+KAFKA_GROUP_ID | group.id | The consumer group this process is consuming on behalf of. Defaults to "zipkin"
+KAFKA_MAX_MESSAGE_SIZE | fetch.message.max.bytes | Maximum size of a message containing spans in bytes. Defaults to 1 MiB
 
 Example usage:
 

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
@@ -21,6 +21,7 @@ class ZipkinKafkaProperties {
   private String zookeeper;
   private String groupId = "zipkin";
   private int streams = 1;
+  private int maxMessageSize = 1024 * 1024;
 
   public String getTopic() {
     return topic;
@@ -52,5 +53,13 @@ class ZipkinKafkaProperties {
 
   public void setStreams(int streams) {
     this.streams = streams;
+  }
+
+  public int getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  public void setMaxMessageSize(int maxMessageSize) {
+    this.maxMessageSize = maxMessageSize;
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinServerConfiguration.java
@@ -217,7 +217,8 @@ public class ZipkinServerConfiguration {
           .topic(kafka.getTopic())
           .zookeeper(kafka.getZookeeper())
           .groupId(kafka.getGroupId())
-          .streams(kafka.getStreams()).writeTo(storage, sampler);
+          .streams(kafka.getStreams())
+          .maxMessageSize(kafka.getMaxMessageSize()).writeTo(storage, sampler);
     }
   }
 

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -36,6 +36,8 @@ kafka:
   group-id: ${KAFKA_GROUP_ID:zipkin}
   # Count of consumer threads consuming the topic
   streams: ${KAFKA_STREAMS:1}
+  # Maximum size of a message containing spans in bytes
+  max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
 scribe:
   category: zipkin
   port: ${COLLECTOR_PORT:9410}

--- a/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaCollectorTest.java
+++ b/zipkin-transports/kafka/src/test/java/zipkin/kafka/KafkaCollectorTest.java
@@ -48,6 +48,16 @@ public class KafkaCollectorTest {
     callback.onSuccess(null);
   };
 
+  @Test
+  public void canSetMaxMessageSize() throws Exception {
+    Builder builder = builder("max_message").maxMessageSize(1);
+
+    try (KafkaCollector processor = newKafkaTransport(builder, consumer)) {
+      assertThat(processor.connector.config().fetchMessageMaxBytes())
+          .isEqualTo(1);
+    }
+  }
+
   /** Ensures legacy encoding works: a single TBinaryProtocol encoded span */
   @Test
   public void messageWithSingleThriftSpan() throws Exception {


### PR DESCRIPTION
Kafka requires global coordination of `message.max.bytes`. This impacts
collectors even if zipkin spans don't approach this amount. To configure
this, we add `KafkaCollector.Builder.maxMessageSize` and the environment
variable `KAFKA_MAX_MESSAGE_SIZE`.

Same as https://github.com/openzipkin/zipkin/pull/1109
See #184