### PR TITLE
Makes explicit which modules require JRE 8

### DIFF
--- a/centralsync-maven-plugin/pom.xml
+++ b/centralsync-maven-plugin/pom.xml
@@ -59,12 +59,10 @@
       <scope>provided</scope>
     </dependency>
 
-
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+
+    <!-- default bytecode version for src/main -->
+    <main.java.version>1.7</main.java.version>
+    <main.signature.artifact>java17</main.signature.artifact>
+
+    <!-- default bytecode version for src/test -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
@@ -303,30 +309,49 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>${maven-shade-plugin.version}</version>
         </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>${animal-sniffer-maven-plugin.version}</version>
-          <configuration>
-            <signature>
-              <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java17</artifactId>
-              <version>1.0</version>
-            </signature>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <inherited>true</inherited>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <!-- Ensure main source tree compiles to Java ${main.java.version} bytecode. -->
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <source>${main.java.version}</source>
+              <target>${main.java.version}</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>${animal-sniffer-maven-plugin.version}</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>${main.signature.artifact}</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Ensures checksums are added to published jars -->
       <plugin>
         <artifactId>maven-install-plugin</artifactId>

--- a/zipkin-junit/pom.xml
+++ b/zipkin-junit/pom.xml
@@ -27,11 +27,6 @@
   <name>Zipkin JUnit</name>
   <description>JUnit rule to spin-up a Zipkin server during tests</description>
 
-  <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -55,14 +50,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- Make sure Java 8 types and methods aren't used -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/zipkin-samplers/zookeeper/pom.xml
+++ b/zipkin-samplers/zookeeper/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
     <curator.version>2.10.0</curator.version>
   </properties>
 

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
     <brave.version>3.6.0</brave.version>
     <zipkin-ui.version>1.39.8</zipkin-ui.version>
     <start-class>zipkin.server.ZipkinServer</start-class>

--- a/zipkin-storage/cassandra/pom.xml
+++ b/zipkin-storage/cassandra/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
     <cassandra-driver-core.version>3.0.0</cassandra-driver-core.version>
   </properties>
 
@@ -35,6 +37,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>storage-guava</artifactId>
     </dependency>
 
     <dependency>
@@ -56,10 +63,6 @@
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin.java</groupId>
-      <artifactId>storage-guava</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/zipkin-storage/elasticsearch/pom.xml
+++ b/zipkin-storage/elasticsearch/pom.xml
@@ -66,32 +66,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <inherited>true</inherited>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- Ensure main source tree compiles to Java 7 bytecode. -->
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Make sure Java 8 types and methods aren't used -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/zipkin-storage/guava/pom.xml
+++ b/zipkin-storage/guava/pom.xml
@@ -61,32 +61,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <inherited>true</inherited>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- Ensure main source tree compiles to Java 7 bytecode. -->
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Make sure Java 8 types and methods aren't used -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/zipkin-storage/jdbc/pom.xml
+++ b/zipkin-storage/jdbc/pom.xml
@@ -28,7 +28,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <jooq.version>3.7.2</jooq.version>
+    <jooq.version>3.7.3</jooq.version>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -55,7 +57,6 @@
       <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/zipkin-transports/scribe/pom.xml
+++ b/zipkin-transports/scribe/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
     <swift.version>0.18.0</swift.version>
   </properties>
 

--- a/zipkin/pom.xml
+++ b/zipkin/pom.xml
@@ -59,29 +59,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <inherited>true</inherited>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- Ensure main source tree compiles to Java 7 bytecode. -->
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Make sure Java 8 types and methods aren't used -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-      </plugin>
       <!-- Use of okio and moshi are internal only -->
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
Before this change, it was hard to tell which module required JRE 8.
This makes it explicit, by defaulting src/main to Java 1.7