### PR TITLE
Add optional configuration: instrumented site(s)

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinUiProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinUiProperties.java
@@ -21,6 +21,7 @@ public class ZipkinUiProperties {
   private String environment;
   private int queryLimit = 10;
   private int defaultLookback = (int) TimeUnit.DAYS.toMillis(7);
+  private String instrumented = ".*";
 
   public int getDefaultLookback() {
     return defaultLookback;
@@ -44,5 +45,13 @@ public class ZipkinUiProperties {
 
   public void setQueryLimit(int queryLimit) {
     this.queryLimit = queryLimit;
+  }
+
+  public String getInstrumented() {
+    return instrumented;
+  }
+
+  public void setInstrumented(String instrumented) {
+    this.instrumented = instrumented;
   }
 }

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -64,6 +64,12 @@ zipkin:
     # Default duration to look back when finding traces or dependency links.
     # Affects the "Start time" element in the UI. 7 days in millis
     default-lookback: ${QUERY_LOOKBACK:604800000}
+    # Which sites this Zipkin UI covers. Regex syntax. (e.g. http:\/\/example.com\/.*)
+    # Multiple sites can be specified, e.g.
+    # - .*example1.com
+    # - .*example2.com
+    # Default is "match all websites"
+    instrumented: ${INSTRUMENTED:.*}
 server:
   port: ${QUERY_PORT:9411}
   compression:


### PR DESCRIPTION
The Zipkin browser extensions will talk to the Zipkin server and
ask it which sites it is supposed to receive traces from. E.g.
you could have multiple Zipkin installations, one for every
environment:

http://www.mysite.com instrumented by http://prod-zipkin.mysite.com
http://dev.mysite.com instrumented by http://dev-zipkin.mysite.com
http://ci.mysite.com instrumented by http://ci-zipkin.mysite.com

By setting the configuration "instrumented" (a regex expression)
we can help the browser extension dispatch trace URLs to the correct
Zipkin server backend.

E.g. for a Zipkin installation at http://dev-zipkin.mysite.com,
setting "instrumented" to ".*:\/\/dev\.mysite\.com\/.*" would mean
all requests accessing dev.mysite.com/* produce traces that
end up in http://dev-zipkin.mysite.com/traces/XXX. The browser
plugin uses that information.