### PR TITLE
Fixes self-tracing auto-configuration by quitting ConditionalOnClass

### DIFF
--- a/zipkin-sampler/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSampler.java
+++ b/zipkin-sampler/zookeeper/src/main/java/zipkin/sampler/zookeeper/ZooKeeperCollectorSampler.java
@@ -63,6 +63,10 @@ import static zipkin.internal.Util.checkNotNull;
 public final class ZooKeeperCollectorSampler extends CollectorSampler implements Closeable {
   final static Logger log = LoggerFactory.getLogger(ZooKeeperCollectorSampler.class);
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Builder {
     float initialRate = 1.0f;
     String basePath = "/zipkin/sampler";
@@ -129,6 +133,9 @@ public final class ZooKeeperCollectorSampler extends CollectorSampler implements
       checkState(checkNotNull(client, "client").getState() == CuratorFrameworkState.STARTED,
           "%s is not started", client.getState());
       return new ZooKeeperCollectorSampler(this, client);
+    }
+
+    Builder() {
     }
   }
 

--- a/zipkin-server/src/main/java/zipkin/server/ConditionalOnSelfTracing.java
+++ b/zipkin-server/src/main/java/zipkin/server/ConditionalOnSelfTracing.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * This helps solve a number of problems including the following, which sometimes only break in an
+ * alpine JRE. The solution is to go with pure properties instead.
+ *
+ * <pre>
+ * <p>ConditionalOnClass(name = "com.github.kristofa.brave.Brave")
+ * <p>ConditionalOnBean(Brave.class)
+ * </pre>
+ */
+@Conditional(ConditionalOnSelfTracing.SelfTracingCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface ConditionalOnSelfTracing {
+  String storageType() default "";
+
+  class SelfTracingCondition extends SpringBootCondition {
+    static final boolean BRAVE_PRESENT = checkForBrave();
+
+    static boolean checkForBrave() {
+      try {
+        Class.forName("com.github.kristofa.brave.Brave");
+        return true;
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+    }
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata a) {
+      if (!BRAVE_PRESENT) {
+        return ConditionOutcome.noMatch("Brave must be in the classpath");
+      }
+
+      String selfTracingEnabled = context.getEnvironment()
+          .getProperty("zipkin.self-tracing.enabled");
+
+      if (!Boolean.valueOf(selfTracingEnabled)) {
+        return ConditionOutcome.noMatch("zipkin.self-tracing.enabled isn't true");
+      }
+
+      String expectedStorageType = AnnotationAttributes.fromMap(
+          a.getAnnotationAttributes(ConditionalOnSelfTracing.class.getName())
+      ).getString("storageType");
+
+      if (expectedStorageType.equals("")) {
+        return ConditionOutcome.match();
+      }
+
+      String storageType = context.getEnvironment().getProperty("zipkin.storage.type");
+      return expectedStorageType.equals(storageType) ?
+          ConditionOutcome.match() :
+          ConditionOutcome.noMatch(
+              "zipkin.storage.type was: " + storageType + " expected " + expectedStorageType);
+    }
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinCassandraProperties.java
@@ -15,9 +15,10 @@ package zipkin.server;
 
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.cassandra.CassandraStorage;
 
 @ConfigurationProperties("cassandra")
-class ZipkinCassandraProperties {
+public class ZipkinCassandraProperties {
   private String keyspace = "zipkin";
   private String contactPoints = "localhost";
   private String localDc;
@@ -98,5 +99,18 @@ class ZipkinCassandraProperties {
 
   public void setIndexTtl(int indexTtl) {
     this.indexTtl = indexTtl;
+  }
+
+  public CassandraStorage.Builder toBuilder() {
+    return CassandraStorage.builder()
+        .keyspace(keyspace)
+        .contactPoints(contactPoints)
+        .localDc(localDc)
+        .maxConnections(maxConnections)
+        .ensureSchema(ensureSchema)
+        .username(username)
+        .password(password)
+        .spanTtl(spanTtl)
+        .indexTtl(indexTtl);
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinElasticsearchProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinElasticsearchProperties.java
@@ -16,6 +16,7 @@ package zipkin.server;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.elasticsearch.ElasticsearchStorage;
 
 @ConfigurationProperties("elasticsearch")
 public class ZipkinElasticsearchProperties {
@@ -61,5 +62,12 @@ public class ZipkinElasticsearchProperties {
   public ZipkinElasticsearchProperties setIndex(String index) {
     this.index = index;
     return this;
+  }
+
+  public ElasticsearchStorage.Builder toBuilder() {
+    return ElasticsearchStorage.builder()
+        .cluster(cluster)
+        .hosts(hosts)
+        .index(index);
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinKafkaProperties.java
@@ -14,9 +14,10 @@
 package zipkin.server;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.kafka.KafkaCollector;
 
 @ConfigurationProperties("kafka")
-class ZipkinKafkaProperties {
+public class ZipkinKafkaProperties {
   private String topic = "zipkin";
   private String zookeeper;
   private String groupId = "zipkin";
@@ -61,5 +62,14 @@ class ZipkinKafkaProperties {
 
   public void setMaxMessageSize(int maxMessageSize) {
     this.maxMessageSize = maxMessageSize;
+  }
+
+  public KafkaCollector.Builder toBuilder() {
+    return KafkaCollector.builder()
+        .topic(topic)
+        .zookeeper(zookeeper)
+        .groupId(groupId)
+        .streams(streams)
+        .maxMessageSize(maxMessageSize);
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinScribeProperties.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinScribeProperties.java
@@ -14,9 +14,10 @@
 package zipkin.server;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin.scribe.ScribeCollector;
 
 @ConfigurationProperties("scribe")
-class ZipkinScribeProperties {
+public class ZipkinScribeProperties {
   private String category = "zipkin";
   private int port = 9410;
 
@@ -34,5 +35,11 @@ class ZipkinScribeProperties {
 
   public void setPort(int port) {
     this.port = port;
+  }
+
+  public ScribeCollector.Builder toBuilder() {
+    return ScribeCollector.builder()
+        .category(category)
+        .port(port);
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
@@ -22,15 +22,14 @@ import com.github.kristofa.brave.spring.ServletHandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import zipkin.server.ConditionalOnSelfTracing;
 
+@ConditionalOnSelfTracing
 @Configuration
 public class ApiTracerConfiguration extends WebMvcConfigurerAdapter {
 

--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -14,7 +14,6 @@
 package zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerTracer;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -22,8 +21,6 @@ import java.net.NetworkInterface;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -32,11 +29,11 @@ import zipkin.CollectorMetrics;
 import zipkin.CollectorSampler;
 import zipkin.Endpoint;
 import zipkin.StorageComponent;
+import zipkin.server.ConditionalOnSelfTracing;
 
 @Configuration
-@ConditionalOnClass(Brave.class)
-@ConditionalOnProperty(name = "zipkin.self-tracing.enabled", havingValue = "true")
-@Import({ApiTracerConfiguration.class, JDBCTracerConfiguration.class})
+@ConditionalOnSelfTracing
+@Import({ApiTracerConfiguration.class, JDBCTracerConfiguration.class, CassandraTracerConfiguration.class})
 public class BraveConfiguration {
 
   /** This gets the lanIP without trying to lookup its name. */

--- a/zipkin-server/src/main/java/zipkin/server/brave/CassandraTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/CassandraTracerConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server.brave;
+
+import com.datastax.driver.core.Session;
+import com.github.kristofa.brave.Brave;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import zipkin.cassandra.CassandraStorage;
+import zipkin.cassandra.SessionFactory;
+import zipkin.server.ConditionalOnSelfTracing;
+
+/** Sets up the Cassandra tracing in Brave as an initialization. */
+@ConditionalOnSelfTracing(storageType = "cassandra")
+@Configuration
+public class CassandraTracerConfiguration {
+  final SessionFactory delegate = new SessionFactory.Default();
+
+  // Lazy to unwind a circular dep: we are tracing the storage used by brave
+  @Autowired @Lazy Brave brave;
+  @Autowired @Lazy LocalSpanCollector collector;
+
+  @Bean SessionFactory tracingSessionFactory() {
+    return new SessionFactory() {
+      @Override public Session create(CassandraStorage storage) {
+        return TracedSession.create(delegate.create(storage), brave, collector);
+      }
+    };
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
@@ -25,19 +25,17 @@ import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.jooq.tools.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import zipkin.Endpoint;
+import zipkin.server.ConditionalOnSelfTracing;
 import zipkin.server.ZipkinMySQLProperties;
 
 /** Sets up the JDBC tracing in Brave as an initialization. */
-@ConditionalOnBean(Brave.class)
 @EnableConfigurationProperties(ZipkinMySQLProperties.class)
-@ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "mysql")
+@ConditionalOnSelfTracing(storageType = "mysql")
 @Configuration
 public class JDBCTracerConfiguration extends DefaultExecuteListener {
 
@@ -45,7 +43,7 @@ public class JDBCTracerConfiguration extends DefaultExecuteListener {
   ZipkinMySQLProperties mysql;
 
   @Bean
-  ExecuteListenerProvider jdbcTraceListenerProvider() {
+  ExecuteListenerProvider tracingExecuteListenerProvider() {
     return new DefaultExecuteListenerProvider(this);
   }
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/LazySession.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/LazySession.java
@@ -18,14 +18,16 @@ import java.io.Closeable;
 import zipkin.internal.Lazy;
 
 final class LazySession extends Lazy<Session> implements Closeable {
-  private final SessionProvider sessionProvider;
+  private final SessionFactory sessionFactory;
+  private final CassandraStorage storage;
 
-  LazySession(SessionProvider sessionProvider) {
-    this.sessionProvider = sessionProvider;
+  LazySession(SessionFactory sessionFactory, CassandraStorage storage) {
+    this.sessionFactory = sessionFactory;
+    this.storage = storage;
   }
 
   @Override protected Session compute() {
-    return sessionProvider.get();
+    return sessionFactory.create(storage);
   }
 
   @Override

--- a/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/SessionFactoryTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/cassandra/SessionFactoryTest.java
@@ -30,81 +30,65 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static zipkin.cassandra.CassandraStorage.builder;
+import static zipkin.cassandra.SessionFactory.Default.buildCluster;
 
-public class SessionProviderTest {
+public class SessionFactoryTest {
+  SessionFactory.Default session = new SessionFactory.Default();
 
   @Test
   public void contactPoints_defaultsToLocalhost() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder());
-
-    assertThat(session.parseContactPoints())
+    assertThat(session.parseContactPoints(builder().build()))
         .containsExactly(new InetSocketAddress("127.0.0.1", 9042));
   }
 
   @Test
   public void contactPoints_defaultsToPort9042() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1"));
-
-    assertThat(session.parseContactPoints())
+    assertThat(session.parseContactPoints(builder().contactPoints("1.1.1.1").build()))
         .containsExactly(new InetSocketAddress("1.1.1.1", 9042));
   }
 
   @Test
   public void contactPoints_defaultsToPort9042_multi() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1:9143,2.2.2.2"));
-
-    assertThat(session.parseContactPoints()).containsExactly(
-        new InetSocketAddress("1.1.1.1", 9143),
-        new InetSocketAddress("2.2.2.2", 9042)
-    );
+    assertThat(session.parseContactPoints(builder().contactPoints("1.1.1.1:9143,2.2.2.2").build()))
+        .containsExactly(
+            new InetSocketAddress("1.1.1.1", 9143),
+            new InetSocketAddress("2.2.2.2", 9042)
+        );
   }
 
   @Test
   public void contactPoints_hostAndPort() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1:9142"));
-
-    assertThat(session.parseContactPoints())
+    assertThat(session.parseContactPoints(builder().contactPoints("1.1.1.1:9142").build()))
         .containsExactly(new InetSocketAddress("1.1.1.1", 9142));
   }
 
   @Test
   public void connectPort_singleContactPoint() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1:9142"));
-
-    assertThat(session.buildCluster().getConfiguration().getProtocolOptions().getPort())
+    assertThat(buildCluster(builder().contactPoints("1.1.1.1:9142").build())
+        .getConfiguration().getProtocolOptions().getPort())
         .isEqualTo(9142);
   }
 
   @Test
   public void connectPort_whenContactPointsHaveSamePort() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1:9143,2.2.2.2:9143"));
-
-    assertThat(session.buildCluster().getConfiguration().getProtocolOptions().getPort())
+    assertThat(buildCluster(builder().contactPoints("1.1.1.1:9143,2.2.2.2:9143").build())
+        .getConfiguration().getProtocolOptions().getPort())
         .isEqualTo(9143);
   }
 
   @Test
   public void connectPort_whenContactPointsHaveMixedPorts_coercesToDefault() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .contactPoints("1.1.1.1:9143,2.2.2.2"));
-
-    assertThat(session.buildCluster().getConfiguration().getProtocolOptions().getPort())
+    assertThat(buildCluster(builder().contactPoints("1.1.1.1:9143,2.2.2.2").build())
+        .getConfiguration().getProtocolOptions().getPort())
         .isEqualTo(9042);
   }
 
   @Test
   public void usernamePassword_impliesNullDelimitedUtf8Bytes() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder()
-        .username("bob")
-        .password("secret"));
-
     Authenticator authenticator =
-        session.buildCluster().getConfiguration().getProtocolOptions().getAuthProvider()
+        buildCluster(builder().username("bob").password("secret").build())
+            .getConfiguration().getProtocolOptions().getAuthProvider()
             .newAuthenticator(new InetSocketAddress("localhost", 8080), null);
 
     byte[] SASLhandshake = {0, 'b', 'o', 'b', 0, 's', 'e', 'c', 'r', 'e', 't'};
@@ -114,17 +98,14 @@ public class SessionProviderTest {
 
   @Test
   public void authProvider_defaultsToNone() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder());
-
-    assertThat(session.buildCluster().getConfiguration().getProtocolOptions().getAuthProvider())
+    assertThat(buildCluster(builder().build())
+        .getConfiguration().getProtocolOptions().getAuthProvider())
         .isEqualTo(AuthProvider.NONE);
   }
 
   @Test
   public void loadBalancing_defaultsToRoundRobin() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder());
-
-    RoundRobinPolicy policy = toRoundRobinPolicy(session);
+    RoundRobinPolicy policy = toRoundRobinPolicy(builder().build());
 
     Host foo = mock(Host.class);
     when(foo.getDatacenter()).thenReturn("foo");
@@ -136,8 +117,8 @@ public class SessionProviderTest {
     assertThat(policy.distance(bar)).isEqualTo(HostDistance.LOCAL);
   }
 
-  static RoundRobinPolicy toRoundRobinPolicy(SessionProvider.Default session) {
-    return (RoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) session.buildCluster()
+  RoundRobinPolicy toRoundRobinPolicy(CassandraStorage storage) {
+    return (RoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) buildCluster(storage)
         .getConfiguration()
         .getPolicies()
         .getLoadBalancingPolicy())
@@ -146,9 +127,7 @@ public class SessionProviderTest {
 
   @Test
   public void loadBalancing_settingLocalDcIgnoresOtherDatacenters() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder().localDc("bar"));
-
-    DCAwareRoundRobinPolicy policy = toDCAwareRoundRobinPolicy(session);
+    DCAwareRoundRobinPolicy policy = toDCAwareRoundRobinPolicy(builder().localDc("bar").build());
 
     Host foo = mock(Host.class);
     when(foo.getDatacenter()).thenReturn("foo");
@@ -160,8 +139,8 @@ public class SessionProviderTest {
     assertThat(policy.distance(bar)).isEqualTo(HostDistance.LOCAL);
   }
 
-  static DCAwareRoundRobinPolicy toDCAwareRoundRobinPolicy(SessionProvider.Default session) {
-    return (DCAwareRoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) session.buildCluster()
+  DCAwareRoundRobinPolicy toDCAwareRoundRobinPolicy(CassandraStorage storage) {
+    return (DCAwareRoundRobinPolicy) ((LatencyAwarePolicy) ((TokenAwarePolicy) buildCluster(storage)
         .getConfiguration()
         .getPolicies()
         .getLoadBalancingPolicy())
@@ -170,19 +149,16 @@ public class SessionProviderTest {
 
   @Test
   public void maxConnections_defaultsTo8() {
-    SessionProvider.Default session = new SessionProvider.Default(new CassandraStorage.Builder());
-
-    PoolingOptions poolingOptions = session.buildCluster().getConfiguration().getPoolingOptions();
+    PoolingOptions poolingOptions = buildCluster(builder().build())
+        .getConfiguration().getPoolingOptions();
 
     assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(8);
   }
 
   @Test
   public void maxConnections_setsMaxConnectionsPerDatacenterLocalHost() {
-    SessionProvider.Default session =
-        new SessionProvider.Default(new CassandraStorage.Builder().maxConnections(16));
-
-    PoolingOptions poolingOptions = session.buildCluster().getConfiguration().getPoolingOptions();
+    PoolingOptions poolingOptions = buildCluster(builder().maxConnections(16).build())
+        .getConfiguration().getPoolingOptions();
 
     assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(16);
   }

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchStorage.java
@@ -25,7 +25,7 @@ import zipkin.spanstore.guava.LazyGuavaStorageComponent;
 
 import static zipkin.internal.Util.checkNotNull;
 
-public class ElasticsearchStorage
+public final class ElasticsearchStorage
     extends LazyGuavaStorageComponent<ElasticsearchSpanStore, ElasticsearchSpanConsumer> {
 
   /**
@@ -35,8 +35,11 @@ public class ElasticsearchStorage
   @VisibleForTesting
   static boolean FLUSH_ON_WRITES;
 
-  public static final class Builder {
+  public static Builder builder() {
+    return new Builder();
+  }
 
+  public static final class Builder {
     String cluster = "elasticsearch";
     List<String> hosts = Collections.singletonList("localhost:9300");
     String index = "zipkin";
@@ -68,6 +71,9 @@ public class ElasticsearchStorage
 
     public ElasticsearchStorage build() {
       return new ElasticsearchStorage(this);
+    }
+
+    Builder() {
     }
   }
 

--- a/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCStorage.java
+++ b/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCStorage.java
@@ -36,7 +36,11 @@ import static zipkin.jdbc.internal.generated.tables.ZipkinSpans.ZIPKIN_SPANS;
 
 public final class JDBCStorage implements StorageComponent {
 
-  public static final class Builder {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public final static class Builder {
     private DataSource datasource;
     private Settings settings = new Settings().withRenderSchema(false);
     private ExecuteListenerProvider listenerProvider;
@@ -64,6 +68,9 @@ public final class JDBCStorage implements StorageComponent {
 
     public JDBCStorage build() {
       return new JDBCStorage(this);
+    }
+
+    Builder() {
     }
   }
 

--- a/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
+++ b/zipkin-transports/kafka/src/main/java/zipkin/kafka/KafkaCollector.java
@@ -42,6 +42,10 @@ import static zipkin.internal.Util.checkNotNull;
  */
 public final class KafkaCollector implements AutoCloseable {
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   /** Configuration including defaults needed to consume spans from a Kafka topic. */
   public static final class Builder {
     CollectorSampler sampler = CollectorSampler.ALWAYS_SAMPLE;
@@ -109,6 +113,9 @@ public final class KafkaCollector implements AutoCloseable {
           return checkNotNull(result, storage + ".asyncSpanConsumer()");
         }
       });
+    }
+
+    Builder() {
     }
   }
 

--- a/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
+++ b/zipkin-transports/scribe/src/main/java/zipkin/scribe/ScribeCollector.java
@@ -37,6 +37,10 @@ import static zipkin.internal.Util.checkNotNull;
  */
 public final class ScribeCollector implements AutoCloseable {
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   /** Configuration including defaults needed to receive spans from a Scribe category. */
   public static final class Builder {
     CollectorSampler sampler = CollectorSampler.ALWAYS_SAMPLE;
@@ -83,6 +87,9 @@ public final class ScribeCollector implements AutoCloseable {
           return checkNotNull(result, storage + ".asyncSpanConsumer()");
         }
       });
+    }
+
+    Builder() {
     }
   }
 


### PR DESCRIPTION
ConditionalOnClass lookups have proven unreliable and extremely
difficult to unwind. For example, the behavior is inconsistent between
the JRE on alpine linux and on a macbook. Rather than continue losing
time on matters like these, this moves to a more explicit condition.