### PR TITLE
Downgrade interop module to Java 7 to support Eclipse users

### DIFF
--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -119,6 +119,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <configuration>
           <skip>true</skip>


### PR DESCRIPTION
There's a bug in Eclipse JDT which makes the interop project
uncompilable with Java 8
(https://bugs.eclipse.org/bugs/show_bug.cgi?id=468276). Since
only one small Java 8 feature was being used in one test
in the whole project, it seems like a small price to pay
to sacrifice that for being able to compile and run in the IDE.