### PR TITLE
Cleans up async behavior in CassandaStorage

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraStorage.java
@@ -178,6 +178,7 @@ public final class CassandraStorage
     session.close();
   }
 
+  /** Truncates all the column families, or throws on any failure. */
   @VisibleForTesting void clear() {
     List<ListenableFuture<?>> futures = new LinkedList<>();
     for (String cf : ImmutableList.of(


### PR DESCRIPTION
There were a couple glitches in the async behavior of cassandra. First,
we were inconsistent on future collecting, and accidentally mapped
against failed futures. Less importantly, we forgot to chain one future
in the storage query.

This fixes those issues and documents the results.

Fixes #199