### PR TITLE
Makes /api/v1/traces serviceName parameter optional

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -31,7 +31,7 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <jmh.version>1.12</jmh.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <zipkin-scrooge.version>1.39.8</zipkin-scrooge.version>
+    <zipkin-scrooge.version>1.40.0</zipkin-scrooge.version>
   </properties>
 
   <dependencies>

--- a/interop/pom.xml
+++ b/interop/pom.xml
@@ -33,7 +33,7 @@
     <libthrift.version>0.9.3</libthrift.version>
     <scalatest.version>2.2.6</scalatest.version>
     <!-- Which implementation version are the span stores compatible with -->
-    <zipkin-scala.version>1.39.8</zipkin-scala.version>
+    <zipkin-scala.version>1.40.0</zipkin-scala.version>
   </properties>
 
   <dependencies>

--- a/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
+++ b/interop/src/main/java/zipkin/interop/ScalaSpanStoreAdapter.java
@@ -69,7 +69,7 @@ public final class ScalaSpanStoreAdapter extends com.twitter.zipkin.storage.Span
   @Override
   public Future<Seq<List<Span>>> getTraces(QueryRequest input) {
     zipkin.QueryRequest.Builder request = zipkin.QueryRequest.builder()
-        .serviceName(input.serviceName())
+        .serviceName(input.serviceName().isDefined() ? input.serviceName().get() : null)
         .spanName(input.spanName().isDefined() ? input.spanName().get() : null)
         .minDuration(input.minDuration().isDefined() ? (Long) input.minDuration().get() : null)
         .maxDuration(input.maxDuration().isDefined() ? (Long) input.maxDuration().get() : null)

--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -31,7 +31,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <brave.version>3.6.0</brave.version>
-    <zipkin-ui.version>1.39.8</zipkin-ui.version>
+    <zipkin-ui.version>1.40.0</zipkin-ui.version>
     <start-class>zipkin.server.ZipkinServer</start-class>
     <maven-invoker-plugin.version>2.0.0</maven-invoker-plugin.version>
   </properties>

--- a/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCSpanStore.java
+++ b/zipkin-storage/jdbc/src/main/java/zipkin/jdbc/JDBCSpanStore.java
@@ -101,8 +101,11 @@ final class JDBCSpanStore implements SpanStore {
 
     SelectConditionStep<Record1<Long>> dsl = context.selectDistinct(ZIPKIN_SPANS.TRACE_ID)
         .from(table)
-        .where(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.eq(request.serviceName))
-        .and(ZIPKIN_SPANS.START_TS.between(endTs - request.lookback * 1000, endTs));
+        .where(ZIPKIN_SPANS.START_TS.between(endTs - request.lookback * 1000, endTs));
+
+    if (request.serviceName != null) {
+      dsl.and(ZIPKIN_ANNOTATIONS.ENDPOINT_SERVICE_NAME.eq(request.serviceName));
+    }
 
     if (request.spanName != null) {
       dsl.and(ZIPKIN_SPANS.NAME.eq(request.spanName));


### PR DESCRIPTION
This makes it possible to make cross-service tools without an explicit
fan-out. This is a port of https://github.com/openzipkin/zipkin/pull/1102

Fixes #182
cc @esbie