### PR TITLE
Adds propagation to cassandra self-tracing

### DIFF
--- a/zipkin-server/pom.xml
+++ b/zipkin-server/pom.xml
@@ -30,7 +30,7 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
-    <brave.version>3.6.0</brave.version>
+    <brave.version>3.7.0</brave.version>
     <zipkin-ui.version>1.40.0</zipkin-ui.version>
     <start-class>zipkin.server.ZipkinServer</start-class>
     <maven-invoker-plugin.version>2.0.0</maven-invoker-plugin.version>

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -94,3 +94,5 @@ logging:
 #     zipkin.internal.DependencyLinker: 'DEBUG'
 #     # log cassandra calls
 #     zipkin.cassandra: 'DEBUG'
+#     # log cassandra trace propagation
+#     com.datastax.driver.core.Message: 'TRACE'


### PR DESCRIPTION
This adds propagation to cassandra self-tracing. When the receiver has
zipkin instrumentation installed, zipkin self-traces will propagate and
include the underlying storage operations

<img width="1014" alt="screen shot 2016-05-06 at 10 07 14 pm" src="https://cloud.githubusercontent.com/assets/64215/15075492/389f98ee-13d7-11e6-91a9-356936d47e8e.png">
