### PR TITLE
Improves json codec performance by being more efficient with hex codec

### DIFF
--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchSpanStore.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/elasticsearch/ElasticsearchSpanStore.java
@@ -187,7 +187,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
     SearchRequestBuilder elasticRequest = client.prepareSearch(indexNameFormatter.catchAll())
         .setTypes(ElasticsearchConstants.SPAN)
         .setSize(MAX_RAW_SPANS)
-        .setQuery(termQuery("traceId", String.format("%016x", traceId)));
+        .setQuery(termQuery("traceId", Util.toLowerHex(traceId)));
 
     return transform(toGuava(elasticRequest.execute()), new Function<SearchResponse, List<Span>>() {
       @Override public List<Span> apply(SearchResponse response) {
@@ -206,7 +206,7 @@ final class ElasticsearchSpanStore implements GuavaSpanStore {
   ListenableFuture<List<List<Span>>> getTracesByIds(Collection<Long> traceIds, String[] indices) {
     List<String> traceIdsStr = new ArrayList<>(traceIds.size());
     for (long traceId : traceIds) {
-      traceIdsStr.add(String.format("%016x", traceId));
+      traceIdsStr.add(Util.toLowerHex(traceId));
     }
     SearchRequestBuilder elasticRequest = client.prepareSearch(indices)
         .setIndicesOptions(IndicesOptions.lenientExpandOpen())

--- a/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
+++ b/zipkin/src/main/java/zipkin/internal/DependencyLinkSpan.java
@@ -54,9 +54,9 @@ public final class DependencyLinkSpan {
   @Override public String toString() {
     StringBuilder json = new StringBuilder("{\"kind\": \"").append(kind).append('\"');
     if (parentId != null) {
-      json.append(", \"parentId\": \"").append(format("%016x", parentId)).append('\"');
+      json.append(", \"parentId\": \"").append(Util.toLowerHex(parentId)).append('\"');
     }
-    json.append(", \"id\": \"").append(format("%016x", id)).append('\"');
+    json.append(", \"id\": \"").append(Util.toLowerHex(id)).append('\"');
     if (service != null) json.append(", \"service\": \"").append(service).append('\"');
     if (peerService != null) json.append(", \"peerService\": \"").append(peerService).append('\"');
     return json.append("}").toString();

--- a/zipkin/src/main/java/zipkin/internal/JsonCodec.java
+++ b/zipkin/src/main/java/zipkin/internal/JsonCodec.java
@@ -55,14 +55,12 @@ public final class JsonCodec implements Codec {
   static final JsonAdapter<Long> HEX_LONG_ADAPTER = new JsonAdapter<Long>() {
     @Override
     public Long fromJson(JsonReader reader) throws IOException {
-      Buffer buffer = new Buffer();
-      buffer.writeUtf8(reader.nextString());
-      return buffer.readHexadecimalUnsignedLong();
+      return Util.lowerHexToUnsignedLong(reader.nextString());
     }
 
     @Override
     public void toJson(JsonWriter writer, Long value) throws IOException {
-      writer.value(String.format("%016x", value));
+      writer.value(Util.toLowerHex(value));
     }
   };
 

--- a/zipkin/src/main/java/zipkin/internal/SpanConsumerLogger.java
+++ b/zipkin/src/main/java/zipkin/internal/SpanConsumerLogger.java
@@ -112,7 +112,7 @@ public final class SpanConsumerLogger {
     message.append("[");
     for (Iterator<Span> iterator = spans.iterator(); iterator.hasNext(); ) {
       Span span = iterator.next();
-      message.append(format("%016x", span.traceId)).append(" -> ").append(format("%016x", span.id));
+      message.append(Util.toLowerHex(span.traceId)).append(" -> ").append(Util.toLowerHex(span.id));
       if (iterator.hasNext()) message.append(", ");
     }
     return message.append("]");

--- a/zipkin/src/test/java/zipkin/internal/UtilTest.java
+++ b/zipkin/src/test/java/zipkin/internal/UtilTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static zipkin.internal.Util.equal;
 import static zipkin.internal.Util.lowerHexToUnsignedLong;
 import static zipkin.internal.Util.midnightUTC;
+import static zipkin.internal.Util.toLowerHex;
 
 public class UtilTest {
   @Test
@@ -53,7 +54,7 @@ public class UtilTest {
   }
 
   @Test
-  public void lowerHexToUnsignedLongTest() throws ParseException {
+  public void lowerHexToUnsignedLongTest() {
     assertThat(lowerHexToUnsignedLong("ffffffffffffffff")).isEqualTo(-1);
     assertThat(lowerHexToUnsignedLong("0")).isEqualTo(0);
     assertThat(lowerHexToUnsignedLong(Long.toHexString(Long.MAX_VALUE))).isEqualTo(Long.MAX_VALUE);
@@ -78,5 +79,15 @@ public class UtilTest {
     } catch (NumberFormatException e) {
 
     }
+  }
+
+  @Test
+  public void toLowerHex_minValue() {
+    assertThat(toLowerHex(Long.MAX_VALUE)).isEqualTo("7fffffffffffffff");
+  }
+
+  @Test
+  public void toLowerHex_fixedLength() {
+    assertThat(toLowerHex(0L)).isEqualTo("0000000000000000");
   }
 }


### PR DESCRIPTION
Before, we were very slow at hex encoding, and this made the json
encoding notably slower than necessary. We were also inefficient by
using regex to check a hex string. This fixes both issues, notably
improving encoding performance.

```
CodecBenchmarks.readLocalSpan_json_java  thrpt   15  155.571 ± 10.273  ops/ms
CodecBenchmarks.writeLocalSpan_json_java  thrpt   15  131.598 ± 11.653  ops/ms

CodecBenchmarks.readLocalSpan_json_java  thrpt   15  162.043 ± 2.652  ops/ms
CodecBenchmarks.writeLocalSpan_json_java  thrpt   15  203.380 ± 6.892  ops/ms
```