### PR TITLE
Fixes Cassandra self-tracing and enables POST tracing

### DIFF
--- a/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinQueryApiV1.java
@@ -30,6 +30,7 @@ import zipkin.Codec;
 import zipkin.QueryRequest;
 import zipkin.Span;
 import zipkin.SpanStore;
+import zipkin.StorageComponent;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static zipkin.internal.Util.checkNotNull;
@@ -54,8 +55,8 @@ public class ZipkinQueryApiV1 {
   /** lazy so transient storage errors don't crash bootstrap */
   @Lazy
   @Autowired
-  public ZipkinQueryApiV1(SpanStore spanStore, Codec.Factory codecFactory) {
-    this.spanStore = spanStore;
+  public ZipkinQueryApiV1(StorageComponent storage, Codec.Factory codecFactory) {
+    this.spanStore = storage.spanStore();
     this.jsonCodec = checkNotNull(codecFactory.get(APPLICATION_JSON_VALUE), APPLICATION_JSON_VALUE);
   }
 

--- a/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/ApiTracerConfiguration.java
@@ -19,12 +19,8 @@ import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.ServerTracer;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.spring.ServletHandlerInterceptor;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.AsyncHandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import zipkin.server.ConditionalOnSelfTracing;
@@ -42,40 +38,6 @@ public class ApiTracerConfiguration extends WebMvcConfigurerAdapter {
     ServletHandlerInterceptor traceInterceptor = new ServletHandlerInterceptor(
         new ServerRequestInterceptor(tracer), new ServerResponseInterceptor(tracer),
         new DefaultSpanNameProvider(), brave.serverSpanThreadBinder());
-    registry.addInterceptor(new NoPOSTHandlerInterceptorAdapter(traceInterceptor));
-  }
-
-  static class NoPOSTHandlerInterceptorAdapter implements AsyncHandlerInterceptor {
-    private final AsyncHandlerInterceptor delegate;
-
-    NoPOSTHandlerInterceptorAdapter(AsyncHandlerInterceptor delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response, Object o) throws Exception {
-      if (!request.getMethod().equals("POST")) {
-        delegate.afterConcurrentHandlingStarted(request, response, o);
-      }
-    }
-
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object o) throws Exception {
-      return request.getMethod().equals("POST") || delegate.preHandle(request, response, o);
-    }
-
-    @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object o, ModelAndView modelAndView) throws Exception {
-      if (!request.getMethod().equals("POST")) {
-        delegate.postHandle(request, response, o, modelAndView);
-      }
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object o, Exception e) throws Exception {
-      if (!request.getMethod().equals("POST")) {
-        delegate.afterCompletion(request, response, o, e);
-      }
-    }
+    registry.addInterceptor(traceInterceptor);
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/BraveConfiguration.java
@@ -14,6 +14,8 @@
 package zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerClientAndLocalSpanState;
+import com.github.kristofa.brave.ThreadLocalServerClientAndLocalSpanState;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -60,8 +62,14 @@ public class BraveConfiguration {
     return new LocalSpanCollector(storage, flushInterval, sampler, metrics);
   }
 
-  @Bean Brave brave(@Qualifier("local") Endpoint localEndpoint, LocalSpanCollector spanCollector) {
-    return new Brave.Builder(localEndpoint.ipv4, localEndpoint.port, localEndpoint.serviceName)
-        .spanCollector(spanCollector).build();
+  @Bean ServerClientAndLocalSpanState braveState(@Qualifier("local") Endpoint localEndpoint) {
+    return new ThreadLocalServerClientAndLocalSpanState(localEndpoint.ipv4, localEndpoint.port,
+        localEndpoint.serviceName);
+  }
+
+  @Bean Brave brave(ServerClientAndLocalSpanState braveState, LocalSpanCollector spanCollector) {
+    return new Brave.Builder(braveState)
+        .spanCollector(spanCollector)
+        .build();
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/JDBCTracerConfiguration.java
@@ -14,21 +14,25 @@
 package zipkin.server.brave;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanState;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.Executor;
 import org.jooq.ExecuteContext;
 import org.jooq.ExecuteListenerProvider;
-import org.jooq.ExecuteType;
 import org.jooq.impl.DefaultExecuteListener;
 import org.jooq.impl.DefaultExecuteListenerProvider;
 import org.jooq.tools.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import zipkin.Endpoint;
 import zipkin.server.ConditionalOnSelfTracing;
 import zipkin.server.ZipkinMySQLProperties;
@@ -42,15 +46,27 @@ public class JDBCTracerConfiguration extends DefaultExecuteListener {
   @Autowired
   ZipkinMySQLProperties mysql;
 
-  @Bean
-  ExecuteListenerProvider tracingExecuteListenerProvider() {
+  @Bean ExecuteListenerProvider tracingExecuteListenerProvider() {
     return new DefaultExecuteListenerProvider(this);
+  }
+
+  @Bean @ConditionalOnMissingBean(Executor.class)
+  public Executor executor(ServerSpanState serverState) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setThreadNamePrefix("JDBCStorage-");
+    executor.initialize();
+    return command -> {
+      ServerSpan currentSpan = serverState.getCurrentServerSpan();
+      executor.execute(() -> {
+        serverState.setCurrentServerSpan(currentSpan);
+        command.run();
+      });
+    };
   }
 
   /** Attach the IP of the remote datasource, knowing that DNS may invalidate this */
   @Bean
-  @Qualifier("jdbc")
-  Endpoint jdbc() throws UnknownHostException {
+  @Qualifier("jdbc") Endpoint jdbc() throws UnknownHostException {
     int ipv4 = ByteBuffer.wrap(InetAddress.getByName(mysql.getHost()).getAddress()).getInt();
     return Endpoint.create("mysql", ipv4, mysql.getPort());
   }
@@ -64,22 +80,29 @@ public class JDBCTracerConfiguration extends DefaultExecuteListener {
 
   @Override
   public void renderEnd(ExecuteContext ctx) {
-    if (ctx.type() == ExecuteType.READ) { // Don't log writes (so as to not loop on collector)
-      brave.clientTracer().startNewSpan("query");
-      String[] batchSQL = ctx.batchSQL();
-      if (!StringUtils.isBlank(ctx.sql())) {
-        brave.clientTracer().submitBinaryAnnotation("jdbc.query", ctx.sql());
-      } else if (batchSQL.length > 0 && batchSQL[batchSQL.length - 1] != null) {
-        brave.clientTracer().submitBinaryAnnotation("jdbc.query", StringUtils.join(batchSQL, '\n'));
-      }
-      brave.clientTracer().setClientSent(jdbcEndpoint.ipv4, jdbcEndpoint.port, jdbcEndpoint.serviceName);
+    // Only join traces, don't start them. This prevents LocalCollector's thread from amplifying.
+    if (brave.serverSpanThreadBinder().getCurrentServerSpan() == null ||
+        brave.serverSpanThreadBinder().getCurrentServerSpan().getSpan() == null) {
+      return;
     }
+
+    brave.clientTracer().startNewSpan(ctx.type().toString().toLowerCase());
+    String[] batchSQL = ctx.batchSQL();
+    if (!StringUtils.isBlank(ctx.sql())) {
+      brave.clientTracer().submitBinaryAnnotation("jdbc.query", ctx.sql());
+    } else if (batchSQL.length > 0 && batchSQL[batchSQL.length - 1] != null) {
+      brave.clientTracer().submitBinaryAnnotation("jdbc.query", StringUtils.join(batchSQL, '\n'));
+    }
+    brave.clientTracer()
+        .setClientSent(jdbcEndpoint.ipv4, jdbcEndpoint.port, jdbcEndpoint.serviceName);
   }
 
   @Override
   public void executeEnd(ExecuteContext ctx) {
-    if (ctx.type() == ExecuteType.READ) { // Don't log writes (so as to not loop on collector)
-      brave.clientTracer().setClientReceived();
+    if (brave.serverSpanThreadBinder().getCurrentServerSpan() == null ||
+        brave.serverSpanThreadBinder().getCurrentServerSpan().getSpan() == null) {
+      return;
     }
+    brave.clientTracer().setClientReceived();
   }
 }

--- a/zipkin-server/src/main/java/zipkin/server/brave/TracedAsyncSpanConsumer.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TracedAsyncSpanConsumer.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server.brave;
+
+import com.github.kristofa.brave.Brave;
+import java.util.List;
+import zipkin.AsyncSpanConsumer;
+import zipkin.Callback;
+import zipkin.Span;
+import zipkin.internal.Nullable;
+
+final class TracedAsyncSpanConsumer implements AsyncSpanConsumer {
+  private final Brave brave;
+  private final AsyncSpanConsumer delegate;
+  private final String component;
+
+  TracedAsyncSpanConsumer(Brave brave, AsyncSpanConsumer delegate) {
+    this.brave = brave;
+    this.delegate = delegate;
+    this.component = delegate.getClass().getSimpleName();
+  }
+
+  @Override public void accept(List<Span> spans, final Callback<Void> callback) {
+    // Only join traces, don't start them. This prevents LocalCollector's thread from amplifying.
+    if (brave.serverSpanThreadBinder().getCurrentServerSpan() == null ||
+        brave.serverSpanThreadBinder().getCurrentServerSpan().getSpan() == null) {
+      delegate.accept(spans, callback);
+      return;
+    }
+
+    brave.localTracer().startNewSpan(component, "accept");
+    delegate.accept(spans, new Callback<Void>() {
+      @Override public void onSuccess(@Nullable Void value) {
+        brave.localTracer().finishSpan();
+        callback.onSuccess(value);
+      }
+
+      @Override public void onError(Throwable t) {
+        brave.localTracer().finishSpan();
+        callback.onError(t);
+      }
+    });
+  }
+}

--- a/zipkin-server/src/main/java/zipkin/server/brave/TracedSpanStore.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TracedSpanStore.java
@@ -13,7 +13,6 @@
  */
 package zipkin.server.brave;
 
-import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.LocalTracer;
 import java.util.List;
 import zipkin.DependencyLink;
@@ -22,13 +21,13 @@ import zipkin.Span;
 import zipkin.SpanStore;
 import zipkin.internal.Nullable;
 
-public final class TracedSpanStore implements SpanStore {
+final class TracedSpanStore implements SpanStore {
   private final LocalTracer tracer;
   private final SpanStore delegate;
   private final String component;
 
-  public TracedSpanStore(Brave brave, SpanStore delegate) {
-    this.tracer = brave.localTracer();
+  TracedSpanStore(LocalTracer tracer, SpanStore delegate) {
+    this.tracer = tracer;
     this.delegate = delegate;
     this.component = delegate.getClass().getSimpleName();
   }

--- a/zipkin-server/src/main/java/zipkin/server/brave/TracedStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TracedStorageComponent.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.server.brave;
+
+import com.github.kristofa.brave.Brave;
+import zipkin.AsyncSpanConsumer;
+import zipkin.AsyncSpanStore;
+import zipkin.CollectorMetrics;
+import zipkin.CollectorSampler;
+import zipkin.SpanStore;
+import zipkin.StorageComponent;
+
+public final class TracedStorageComponent implements StorageComponent {
+  private final Brave brave;
+  private final StorageComponent delegate;
+
+  public TracedStorageComponent(Brave brave, StorageComponent delegate) {
+    this.brave = brave;
+    this.delegate = delegate;
+  }
+
+  @Override public SpanStore spanStore() {
+    return new TracedSpanStore(brave.localTracer(), delegate.spanStore());
+  }
+
+  @Override public AsyncSpanStore asyncSpanStore() {
+    return delegate.asyncSpanStore();
+  }
+
+  @Override
+  public AsyncSpanConsumer asyncSpanConsumer(CollectorSampler sampler, CollectorMetrics metrics) {
+    return new TracedAsyncSpanConsumer(brave, delegate.asyncSpanConsumer(sampler, metrics));
+  }
+
+  @Override public void close() {
+    delegate.close();
+  }
+}

--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraDependenciesWriter.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraDependenciesWriter.java
@@ -30,6 +30,7 @@ import zipkin.DependencyLink;
 import zipkin.internal.Dependencies;
 import zipkin.internal.Util;
 
+import static zipkin.cassandra.CassandraUtil.bindWithName;
 import static zipkin.cassandra.CassandraUtil.iso8601;
 
 final class CassandraDependenciesWriter {
@@ -55,7 +56,7 @@ final class CassandraDependenciesWriter {
   ListenableFuture<?> storeDependencies(long epochDayMillis, ByteBuffer dependencies) {
     Date startFlooredToDay = new Date(epochDayMillis);
     try {
-      BoundStatement bound = insertDependencies.bind()
+      BoundStatement bound = bindWithName(insertDependencies, "insert-dependencies")
           .setTimestamp("day", startFlooredToDay)
           .setBytes("dependencies", dependencies);
 

--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraUtil.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/CassandraUtil.java
@@ -14,6 +14,8 @@
 
 package zipkin.cassandra;
 
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
 import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import java.nio.ByteBuffer;
@@ -110,6 +112,10 @@ final class CassandraUtil {
 
   static Function<Map<Long, Long>, Set<Long>> keyset() {
     return (Function) KeySet.INSTANCE;
+  }
+
+  static BoundStatement bindWithName(PreparedStatement prepared, String name) {
+    return new NamedBoundStatement(prepared, name);
   }
 
   enum KeySet implements Function<Map<Object, ?>, Set<Object>> {

--- a/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/NamedBoundStatement.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/cassandra/NamedBoundStatement.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+
+/** Used to assign a friendly name when tracing and debugging */
+public final class NamedBoundStatement extends BoundStatement {
+
+  public final String name;
+
+  NamedBoundStatement(PreparedStatement statement, String name) {
+    super(statement);
+    this.name = name;
+  }
+
+  @Override public String toString(){
+    return name;
+  }
+}


### PR DESCRIPTION
This fixes a thread propagation issue in Cassandra self-tracing that
prevented us from seeing all the spans.

This also logs traces for the POST endpoint, so that we can compare
how different implementations perform and are implemented.

Here's comparisons of all the storage systems storing a 4-span trace. The graph is the result of the second POST, so as to avoid showing lag from first network connect etc.

mem:
![mem](https://cloud.githubusercontent.com/assets/64215/15092104/732eb6d2-1492-11e6-9a90-c2e7f789698e.png)

mysql:
![mysql](https://cloud.githubusercontent.com/assets/64215/15092110/99aa505a-1492-11e6-958c-0986193921d3.png)

cassandra:
![cassandra](https://cloud.githubusercontent.com/assets/64215/15092109/85984644-1492-11e6-8be1-25551ae2524f.png)

elasticsearch:
![elasticsearch](https://cloud.githubusercontent.com/assets/64215/15092107/7b03f160-1492-11e6-973d-bcd99b933c02.png)

Notice that we've not yet instrumented elasticsearch, so we can't really tell how much work is going on.