### PR TITLE
Document release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+# Zipkin Release Process
+
+This repo uses semantic versions with a twist: we update minors on api-breaks until we hit 1.0. Please keep this
+in mind when choosing version numbers.
+
+1. **Alert others you are releasing**
+
+   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
+   a release, alert others on [gitter](https://gitter.im/openzipkin/zipkin) so that they don't accidentally merge
+   anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+
+1. **Push a git tag**
+
+   The tag should be of the format `release-N.M.L`, for example `release-0.18.1`. Note that the release automation
+   will verify that the version in the tag matches the version in `pom.xml` (minus `-SNAPSHOT`), and abort the release
+   if it's not.
+
+1. **Wait for Travis CI**
+
+   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
+   the version, publishes artifacts, and syncs to Maven Central.
+
+1. **Publish `docker-zipkin-java`**
+
+   Refer to [docker-zipkin-java/RELEASE.md](https://github.com/openzipkin/docker-zipkin-java/blob/master/RELEASE.md).


### PR DESCRIPTION
I'm also planning to provide graphs similar to the ones shown in https://github.com/openzipkin/zipkin/blob/master/RELEASE.md. They'll be considerably simpler here.

Just realized when looking at the release process of `zipkin`: the automation in `zipkin-java` currently has no support for releasing RCs. May not be a problem, and it keeps the flow simpler.