### PR TITLE
Deploys snapshots and versions from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,12 @@ install:
 script:
   - ./travis/publish.sh
 
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
+branches:
+  except:
+    - /^[0-9]/
+
 env:
   global:
   # Ex. travis encrypt BINTRAY_USER=your_github_account


### PR DESCRIPTION
Since our release task makes tags, not branches, version commits end up
on master. These deploy, so we can't also build the tag, too.

This consolidates code around deployment to the master branch, and uses
the maven version to tell if it should be synchronized to maven central
or not.

Fixes #220
Partially reverts a4bf8e1c47eae314c44fac075c89797817c93876