### PR TITLE
Extracts Component, which has a check() method for determining health

### DIFF
--- a/interop/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
+++ b/interop/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
@@ -13,8 +13,8 @@
  */
 package zipkin.storage.cassandra;
 
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
 import zipkin.internal.LazyCloseable;
 
 enum CassandraTestGraph {
@@ -30,13 +30,10 @@ enum CassandraTestGraph {
 
     @Override protected CassandraStorage compute() {
       if (ex != null) throw ex;
-      CassandraStorage result = new CassandraStorage.Builder().keyspace("test_zipkin").build();
-      try {
-        result.spanStore().getServiceNames();
-        return result;
-      } catch (NoHostAvailableException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
-      }
+      CassandraStorage result = CassandraStorage.builder().keyspace("test_zipkin").build();
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
     }
   };
 }

--- a/interop/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/interop/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -13,8 +13,8 @@
  */
 package zipkin.storage.elasticsearch;
 
-import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
 import zipkin.internal.LazyCloseable;
 
 enum ElasticsearchTestGraph {
@@ -30,12 +30,9 @@ enum ElasticsearchTestGraph {
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;
       ElasticsearchStorage result = new ElasticsearchStorage.Builder().build();
-      try {
-        result.spanStore().getServiceNames();
-        return result;
-      } catch (NoNodeAvailableException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
-      }
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
     }
   };
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <cassandra-driver-core.version>3.0.1</cassandra-driver-core.version>
     <moshi.version>1.1.0</moshi.version>
     <okio.version>1.8.0</okio.version>
+    <jooq.version>3.8.0</jooq.version>
     <spring-boot.version>1.3.5.RELEASE</spring-boot.version>
     <!-- MySQL connector is GPL, even if it has an OSS exception.
          https://www.mysql.com/about/legal/licensing/foss-exception/
@@ -213,6 +214,12 @@
         <artifactId>cassandra-driver-core</artifactId>
         <version>${cassandra-driver-core.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq</artifactId>
+        <version>${jooq.version}</version>
+      </dependency>
+      <!-- End spring-boot-dependencies overrides -->
 
       <dependency>
         <groupId>com.squareup.moshi</groupId>

--- a/zipkin-collector/scribe/src/main/java/zipkin/collector/scribe/ScribeCollector.java
+++ b/zipkin-collector/scribe/src/main/java/zipkin/collector/scribe/ScribeCollector.java
@@ -25,6 +25,7 @@ import zipkin.collector.CollectorSampler;
 import zipkin.storage.StorageComponent;
 import zipkin.storage.guava.GuavaSpanConsumer;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyList;
 import static zipkin.internal.Util.checkNotNull;
 
@@ -89,9 +90,19 @@ public final class ScribeCollector implements CollectorComponent, Closeable {
     server = new ThriftServer(processor, new ThriftServerConfig().setPort(builder.port));
   }
 
+  /** Will throw an exception if the {@link Builder#port(int) port} is already in use. */
   @Override public ScribeCollector start() {
     server.start();
     return this;
+  }
+
+  @Override public CheckResult check() {
+    try {
+      checkState(server.isRunning(), "server not running");
+    } catch (RuntimeException e) {
+      return CheckResult.failed(e);
+    }
+    return CheckResult.OK;
   }
 
   @Override

--- a/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeCollectorTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeCollectorTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.collector.scribe;
+
+import org.jboss.netty.channel.ChannelException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Component.CheckResult;
+import zipkin.storage.InMemoryStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScribeCollectorTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void check_failsWhenNotStarted() {
+    try (ScribeCollector scribe =
+             ScribeCollector.builder().storage(new InMemoryStorage()).port(12345).build()) {
+
+      CheckResult result = scribe.check();
+      assertThat(result.ok).isFalse();
+      assertThat(result.exception)
+          .isInstanceOf(IllegalStateException.class);
+
+      scribe.start();
+      assertThat(scribe.check().ok).isTrue();
+    }
+  }
+
+  @Test
+  public void start_failsWhenCantBindPort() {
+    thrown.expect(ChannelException.class);
+    thrown.expectMessage("Failed to bind to: 0.0.0.0/0.0.0.0:12345");
+
+    ScribeCollector.Builder builder =
+        ScribeCollector.builder().storage(new InMemoryStorage()).port(12345);
+
+    try (ScribeCollector first = builder.build().start()) {
+      try (ScribeCollector samePort = builder.build().start()) {
+      }
+    }
+  }
+}

--- a/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeSpanConsumerTest.java
+++ b/zipkin-collector/scribe/src/test/java/zipkin/collector/scribe/ScribeSpanConsumerTest.java
@@ -219,6 +219,10 @@ public class ScribeSpanConsumerTest {
             return consumer;
           }
 
+          @Override public CheckResult check() {
+            return CheckResult.OK;
+          }
+
           @Override public void close() {
             throw new AssertionError();
           }

--- a/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
+++ b/zipkin-junit/src/test/java/zipkin/junit/HttpStorage.java
@@ -61,6 +61,15 @@ final class HttpStorage implements StorageComponent {
     return consumer;
   }
 
+  @Override public CheckResult check() {
+    try {
+      spanStore.getServiceNames();
+    } catch (RuntimeException e){
+      return CheckResult.failed(e);
+    }
+    return CheckResult.OK;
+  }
+
   @Override public void close() {
     client.connectionPool().evictAll();
   }

--- a/zipkin-server/src/it/execjar/src/test/java/zipkin/execjar/DoesntCrashWhenKafkaZooKeeperIsDownTest.java
+++ b/zipkin-server/src/it/execjar/src/test/java/zipkin/execjar/DoesntCrashWhenKafkaZooKeeperIsDownTest.java
@@ -23,25 +23,11 @@ import zipkin.server.ZipkinServer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class DoesntCrashWhenCassandraIsDownTest {
+public class DoesntCrashWhenKafkaZooKeeperIsDownTest {
 
   @Rule
   public ExecJarRule zipkin = new ExecJarRule(ZipkinServer.class)
-      .putEnvironment("STORAGE_TYPE", "cassandra")
-      .putEnvironment("CASSANDRA_CONTACT_POINTS", "idontexist");
-
-  @Test
-  public void startsButReturns500QueryingStorage() {
-    try {
-      HttpURLConnection connection = (HttpURLConnection)
-          URI.create("http://localhost:" + zipkin.port() + "/api/v1/services").toURL()
-              .openConnection();
-
-      assertEquals(500, connection.getResponseCode());
-    } catch (RuntimeException | IOException e) {
-      fail(String.format("unexpected error!%s%n%s", e.getMessage(), zipkin.consoleOutput()));
-    }
-  }
+      .putEnvironment("KAFKA_ZOOKEEPER", "idontexist");
 
   @Test
   public void startsButReturnsFailedHealthCheck() {

--- a/zipkin-server/src/main/java/zipkin/server/ZipkinHealthIndicator.java
+++ b/zipkin-server/src/main/java/zipkin/server/ZipkinHealthIndicator.java
@@ -11,21 +11,21 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage;
+package zipkin.server;
 
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 import zipkin.Component;
 
-/**
- * A component that provides storage interfaces used for spans and aggregations. Implementations are
- * free to provide other interfaces, but the ones declared here must be supported.
- *
- * @see InMemoryStorage
- */
-public interface StorageComponent extends Component {
+public final class ZipkinHealthIndicator implements HealthIndicator {
+  final Component component;
 
-  SpanStore spanStore();
+  public ZipkinHealthIndicator(Component component) {
+    this.component = component;
+  }
 
-  AsyncSpanStore asyncSpanStore();
-
-  AsyncSpanConsumer asyncSpanConsumer();
+  @Override public Health health() {
+    Component.CheckResult result = component.check();
+    return result.ok ? Health.up().build() : Health.down(result.exception).build();
+  }
 }

--- a/zipkin-server/src/main/java/zipkin/server/brave/TracedSession.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TracedSession.java
@@ -32,6 +32,7 @@ import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
@@ -102,7 +103,12 @@ public final class TracedSession extends AbstractInvocationHandler implements La
       brave.clientSpanThreadBinder().setCurrentSpan(null);
       return new BraveResultSetFuture(target.executeAsync(statement), brave);
     }
-    return method.invoke(target, args);
+    try {
+      return method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException) throw e.getCause();
+      throw e;
+    }
   }
 
   @Override public void update(Host host, Statement statement, Exception e, long nanos) {

--- a/zipkin-server/src/main/java/zipkin/server/brave/TracedStorageComponent.java
+++ b/zipkin-server/src/main/java/zipkin/server/brave/TracedStorageComponent.java
@@ -42,6 +42,10 @@ public final class TracedStorageComponent implements StorageComponent {
     return new TracedAsyncSpanConsumer(brave, delegate.asyncSpanConsumer());
   }
 
+  @Override public CheckResult check() {
+    return delegate.check();
+  }
+
   @Override public void close() throws IOException {
     delegate.close();
   }

--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -14,6 +14,7 @@
 
 package zipkin.storage.cassandra;
 
+import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
@@ -173,6 +174,15 @@ public final class CassandraStorage
 
   @Override protected CassandraSpanConsumer computeGuavaSpanConsumer() {
     return new CassandraSpanConsumer(session.get(), bucketCount, spanTtl, indexTtl);
+  }
+
+  @Override public CheckResult check() {
+    try {
+      session.get().execute(QueryBuilder.select("trace_id").from("traces").limit(1));
+    } catch (RuntimeException e) {
+      return CheckResult.failed(e);
+    }
+    return CheckResult.OK;
   }
 
   @Override public void close() throws IOException {

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraStorageTest.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraStorageTest.java
@@ -11,21 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage;
+package zipkin.storage.cassandra;
 
-import zipkin.Component;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.junit.Test;
+import zipkin.Component.CheckResult;
 
-/**
- * A component that provides storage interfaces used for spans and aggregations. Implementations are
- * free to provide other interfaces, but the ones declared here must be supported.
- *
- * @see InMemoryStorage
- */
-public interface StorageComponent extends Component {
+import static org.assertj.core.api.Assertions.assertThat;
 
-  SpanStore spanStore();
+public class CassandraStorageTest {
 
-  AsyncSpanStore asyncSpanStore();
+  @Test
+  public void check_failsInsteadOfThrowing() {
+    CheckResult result =
+        CassandraStorage.builder().contactPoints("1.1.1.1").build().check();
 
-  AsyncSpanConsumer asyncSpanConsumer();
+    assertThat(result.ok).isFalse();
+    assertThat(result.exception)
+        .isInstanceOf(NoHostAvailableException.class);
+  }
 }

--- a/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
+++ b/zipkin-storage/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
@@ -13,8 +13,8 @@
  */
 package zipkin.storage.cassandra;
 
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
 import zipkin.internal.LazyCloseable;
 
 enum CassandraTestGraph {
@@ -30,13 +30,10 @@ enum CassandraTestGraph {
 
     @Override protected CassandraStorage compute() {
       if (ex != null) throw ex;
-      CassandraStorage result = new CassandraStorage.Builder().keyspace("test_zipkin").build();
-      try {
-        result.spanStore().getServiceNames();
-        return result;
-      } catch (NoHostAvailableException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
-      }
+      CassandraStorage result = CassandraStorage.builder().keyspace("test_zipkin").build();
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
     }
   };
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchStorageTest.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchStorageTest.java
@@ -11,21 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.storage;
+package zipkin.storage.elasticsearch;
 
-import zipkin.Component;
+import org.elasticsearch.client.transport.NoNodeAvailableException;
+import org.junit.Test;
+import zipkin.Component.CheckResult;
 
-/**
- * A component that provides storage interfaces used for spans and aggregations. Implementations are
- * free to provide other interfaces, but the ones declared here must be supported.
- *
- * @see InMemoryStorage
- */
-public interface StorageComponent extends Component {
+import static org.assertj.core.api.Assertions.assertThat;
 
-  SpanStore spanStore();
+public class ElasticsearchStorageTest {
 
-  AsyncSpanStore asyncSpanStore();
+  @Test
+  public void check_failsInsteadOfThrowing() {
+    CheckResult result =
+        ElasticsearchStorage.builder().cluster("1.1.1.1").build().check();
 
-  AsyncSpanConsumer asyncSpanConsumer();
+    assertThat(result.ok).isFalse();
+    assertThat(result.exception)
+        .isInstanceOf(NoNodeAvailableException.class);
+  }
 }

--- a/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/zipkin-storage/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -13,8 +13,8 @@
  */
 package zipkin.storage.elasticsearch;
 
-import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.junit.AssumptionViolatedException;
+import zipkin.Component.CheckResult;
 import zipkin.internal.LazyCloseable;
 
 enum ElasticsearchTestGraph {
@@ -30,12 +30,9 @@ enum ElasticsearchTestGraph {
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;
       ElasticsearchStorage result = new ElasticsearchStorage.Builder().build();
-      try {
-        result.spanStore().getServiceNames();
-        return result;
-      } catch (NoNodeAvailableException e) {
-        throw ex = new AssumptionViolatedException(e.getMessage());
-      }
+      CheckResult check = result.check();
+      if (check.ok) return result;
+      throw ex = new AssumptionViolatedException(check.exception.getMessage());
     }
   };
 }

--- a/zipkin-storage/jdbc/pom.xml
+++ b/zipkin-storage/jdbc/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <jooq.version>3.8.0</jooq.version>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
   </properties>
@@ -42,7 +41,6 @@
     <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>jooq</artifactId>
-      <version>${jooq.version}</version>
     </dependency>
 
     <dependency>
@@ -55,6 +53,13 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zipkin-storage/jdbc/src/test/java/zipkin/storage/jdbc/JDBCStorageTest.java
+++ b/zipkin-storage/jdbc/src/test/java/zipkin/storage/jdbc/JDBCStorageTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.storage.jdbc;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.jooq.exception.DataAccessException;
+import org.junit.Test;
+import zipkin.Component.CheckResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JDBCStorageTest {
+
+  @Test
+  public void check_failsInsteadOfThrowing() throws SQLException {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new SQLException("foo"));
+
+    CheckResult result = JDBCStorage.builder()
+        .executor(Runnable::run)
+        .datasource(dataSource)
+        .build().check();
+
+    assertThat(result.ok).isFalse();
+    assertThat(result.exception)
+        .isInstanceOf(SQLException.class);
+  }
+}

--- a/zipkin/src/main/java/zipkin/Component.java
+++ b/zipkin/src/main/java/zipkin/Component.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import java.io.Closeable;
+import java.io.IOException;
+import zipkin.internal.Nullable;
+
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * Components are object graphs used to compose a zipkin service or client. For example, a storage
+ * component might return a query api.
+ *
+ * <p>Components are lazy with regards to I/O. They can be injected directly to other components so
+ * as to avoid crashing the application graph if the a network service is unavailable.
+ */
+public interface Component extends Closeable {
+
+  /**
+   * Answers the question: Are operations on this component likely to succeed?
+   *
+   * <p>Implementations should initialize the component if necessary. It should test a remote
+   * connection, or consult a trusted source to derive the result. They should use least resources
+   * possible to establish a meaningful result, and be safe to call many times, even concurrently.
+   *
+   * @see CheckResult#OK
+   */
+  CheckResult check();
+
+  /**
+   * Closes any network resources created implicitly by the component.
+   *
+   * <p>For example, if this created a connection, it would close it. If it was provided one, this
+   * would close any sessions, but leave the connection open.
+   */
+  @Override void close() throws IOException;
+
+  final class CheckResult {
+    public static final CheckResult OK = new CheckResult(true, null);
+
+    public static final CheckResult failed(@Nullable Exception exception) {
+      return new CheckResult(false, checkNotNull(exception, "exception"));
+    }
+
+    public final boolean ok;
+
+    /** Present when not ok */
+    @Nullable public final Exception exception;
+
+    CheckResult(boolean ok, Exception exception) {
+      this.ok = ok;
+      this.exception = exception;
+    }
+  }
+}

--- a/zipkin/src/main/java/zipkin/collector/CollectorComponent.java
+++ b/zipkin/src/main/java/zipkin/collector/CollectorComponent.java
@@ -13,23 +13,20 @@
  */
 package zipkin.collector;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.List;
+import zipkin.Component;
+import zipkin.Span;
 import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
-import zipkin.Span;
 import zipkin.storage.StorageComponent;
 
 /**
  * The collector represents the server-side of a transport. Its job is to take spans from a
  * transport and store ones it has sampled.
  *
- * <p>This component is lazy with regards to I/O. It can be injected directly to other components so
- * as to avoid crashing the application graph if the storage backend is unavailable. You must call
- * {@link #start()} to start collecting spans.
+ * <p>Call {@link #start()} to start collecting spans.
  */
-public interface CollectorComponent extends Closeable {
+public interface CollectorComponent extends Component {
 
   /**
    * Starts the server-side of the transport, typically listening or looking up a queue.
@@ -59,12 +56,4 @@ public interface CollectorComponent extends Closeable {
 
     CollectorComponent build();
   }
-
-  /**
-   * Closes any network resources created implicitly by the component.
-   *
-   * <p>For example, if this created a connection, it would close it. If it was provided one, this
-   * would close any sessions, but leave the connection open.
-   */
-  @Override void close() throws IOException;
 }

--- a/zipkin/src/main/java/zipkin/storage/InMemoryStorage.java
+++ b/zipkin/src/main/java/zipkin/storage/InMemoryStorage.java
@@ -55,6 +55,10 @@ public final class InMemoryStorage implements StorageComponent {
     return spanStore.acceptedSpanCount;
   }
 
+  @Override public CheckResult check() {
+    return CheckResult.OK;
+  }
+
   @Override public void close() {
   }
 }


### PR DESCRIPTION
This pulls out an interface: Component, which has the ability to report
its health via a `check()` method. This is ported to all storage and
collector components. Notably, this also fixes a crash when Kafka isn't
running when zipkin was started.

Fixes #140

Inspired by:
* https://github.com/Netflix/denominator/blob/master/core/src/main/java/denominator/CheckConnection.java
* https://github.com/dropwizard/metrics/blob/3.1-maintenance/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java