### PR TITLE
Adds cache headers to /api/v1/services and /api/v1/spans

### DIFF
--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -53,6 +53,8 @@ zipkin:
   query:
     # 7 days in millis
     lookback: ${QUERY_LOOKBACK:86400000}
+    # The Cache-Control max-age (seconds) for /api/v1/services and /api/v1/spans
+    names-max-age: 300
   storage:
     type: ${STORAGE_TYPE:mem}
   ui:


### PR DESCRIPTION
Same as https://github.com/openzipkin/zipkin/issues/718, except
including the span names endpoint (/api/v1/spans)

Defaults to 300 seconds, overridable via zipkin.query.names-max-age

Fixes #229