### PR TITLE
Revert "Namespaces spring configuration to match package names"

### DIFF
--- a/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
@@ -16,7 +16,7 @@ package zipkin.autoconfigure.collector.kafka;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.kafka.KafkaCollector;
 
-@ConfigurationProperties("zipkin.collector.kafka")
+@ConfigurationProperties("kafka")
 public class ZipkinKafkaCollectorProperties {
   private String topic = "zipkin";
   private String zookeeper;

--- a/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorProperties.java
@@ -16,7 +16,7 @@ package zipkin.autoconfigure.collector.scribe;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.scribe.ScribeCollector;
 
-@ConfigurationProperties("zipkin.collector.scribe")
+@ConfigurationProperties("scribe")
 public class ZipkinScribeCollectorProperties {
   private String category = "zipkin";
   private int port = 9410;

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.cassandra.CassandraStorage;
 
-@ConfigurationProperties("zipkin.storage.cassandra")
+@ConfigurationProperties("cassandra")
 public class ZipkinCassandraStorageProperties {
   private String keyspace = "zipkin";
   private String contactPoints = "localhost";

--- a/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -18,9 +18,8 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.elasticsearch.ElasticsearchStorage;
 
-@ConfigurationProperties("zipkin.storage.elasticsearch")
+@ConfigurationProperties("elasticsearch")
 public class ZipkinElasticsearchStorageProperties {
-
   /**
    * The elasticsearch cluster to connect to, defaults to "elasticsearch".
    */

--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
@@ -15,7 +15,7 @@ package zipkin.autoconfigure.storage.mysql;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("zipkin.storage.mysql")
+@ConfigurationProperties("mysql")
 public class ZipkinMySQLStorageProperties {
   private String host = "localhost";
   private int port = 3306;

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -1,3 +1,46 @@
+cassandra:
+  # Comma separated list of hosts / ip addresses part of Cassandra cluster.
+  contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
+  # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+  local-dc: ${CASSANDRA_LOCAL_DC:}
+  # Will throw an exception on startup if authentication fails.
+  username: ${CASSANDRA_USERNAME:}
+  password: ${CASSANDRA_PASSWORD:}
+  keyspace: ${CASSANDRA_KEYSPACE:zipkin}
+  # Max pooled connections per datacenter-local host.
+  max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
+  # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
+  ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
+  # 7 days in seconds
+  span-ttl: ${CASSANDRA_SPAN_TTL:604800}
+  # 3 days in seconds
+  index-ttl: ${CASSANDRA_INDEX_TTL:259200}
+mysql:
+  host: ${MYSQL_HOST:localhost}
+  port: ${MYSQL_TCP_PORT:3306}
+  username: ${MYSQL_USER:}
+  password: ${MYSQL_PASS:}
+  db: ${MYSQL_DB:zipkin}
+  max-active: ${MYSQL_MAX_CONNECTIONS:10}
+  use-ssl: ${MYSQL_USE_SSL:false}
+elasticsearch:
+  cluster: ${ES_CLUSTER:elasticsearch}
+  hosts: ${ES_HOSTS:localhost:9300}
+  index: ${ES_INDEX:zipkin}
+kafka:
+  # ZooKeeper host string, comma-separated host:port value.
+  zookeeper: ${KAFKA_ZOOKEEPER:}
+  # Name of topic to poll for spans
+  topic: ${KAFKA_TOPIC:zipkin}
+  # Consumer group this process is consuming on behalf of.
+  group-id: ${KAFKA_GROUP_ID:zipkin}
+  # Count of consumer threads consuming the topic
+  streams: ${KAFKA_STREAMS:1}
+  # Maximum size of a message containing spans in bytes
+  max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
+scribe:
+  category: zipkin
+  port: ${COLLECTOR_PORT:9410}
 zipkin:
   self-tracing:
     # Set to false to disable self-tracing. Defaults to true
@@ -7,20 +50,6 @@ zipkin:
   collector:
     # percentage to traces to retain
     sample-rate: ${COLLECTOR_SAMPLE_RATE:1.0}
-    scribe:
-      category: zipkin
-      port: ${COLLECTOR_PORT:9410}
-    kafka:
-      # ZooKeeper host string, comma-separated host:port value.
-      zookeeper: ${KAFKA_ZOOKEEPER:}
-      # Name of topic to poll for spans
-      topic: ${KAFKA_TOPIC:zipkin}
-      # Consumer group this process is consuming on behalf of.
-      group-id: ${KAFKA_GROUP_ID:zipkin}
-      # Count of consumer threads consuming the topic
-      streams: ${KAFKA_STREAMS:1}
-      # Maximum size of a message containing spans in bytes
-      max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
   query:
     # 7 days in millis
     lookback: ${QUERY_LOOKBACK:86400000}
@@ -28,35 +57,6 @@ zipkin:
     names-max-age: 300
   storage:
     type: ${STORAGE_TYPE:mem}
-    cassandra:
-      # Comma separated list of hosts / ip addresses part of Cassandra cluster.
-      contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
-      # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
-      local-dc: ${CASSANDRA_LOCAL_DC:}
-      # Will throw an exception on startup if authentication fails.
-      username: ${CASSANDRA_USERNAME:}
-      password: ${CASSANDRA_PASSWORD:}
-      keyspace: ${CASSANDRA_KEYSPACE:zipkin}
-      # Max pooled connections per datacenter-local host.
-      max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
-      # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
-      ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
-      # 7 days in seconds
-      span-ttl: ${CASSANDRA_SPAN_TTL:604800}
-      # 3 days in seconds
-      index-ttl: ${CASSANDRA_INDEX_TTL:259200}
-    mysql:
-      host: ${MYSQL_HOST:localhost}
-      port: ${MYSQL_TCP_PORT:3306}
-      username: ${MYSQL_USER:}
-      password: ${MYSQL_PASS:}
-      db: ${MYSQL_DB:zipkin}
-      max-active: ${MYSQL_MAX_CONNECTIONS:10}
-      use-ssl: ${MYSQL_USE_SSL:false}
-    elasticsearch:
-      cluster: ${ES_CLUSTER:elasticsearch}
-      hosts: ${ES_HOSTS:localhost:9300}
-      index: ${ES_INDEX:zipkin}
   ui:
     ## Values below here are mapped to ZipkinServerProperties.UI, served as /config.json
     # Default limit for Find Traces


### PR DESCRIPTION
Config property namespacing broke environment variable mapping.
This reverts that and also fixes a pom glitch in elasticsearch.