### PR TITLE
Namespaces spring configuration to match package names

### DIFF
--- a/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-kafka/src/main/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorProperties.java
@@ -16,7 +16,7 @@ package zipkin.autoconfigure.collector.kafka;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.kafka.KafkaCollector;
 
-@ConfigurationProperties("kafka")
+@ConfigurationProperties("zipkin.collector.kafka")
 public class ZipkinKafkaCollectorProperties {
   private String topic = "zipkin";
   private String zookeeper;

--- a/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/collector-kafka/src/test/java/zipkin/autoconfigure/collector/kafka/ZipkinKafkaCollectorAutoConfigurationTests.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.collector.kafka;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.CollectorSampler;
+import zipkin.collector.kafka.KafkaCollector;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.StorageComponent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinKafkaCollectorAutoConfigurationTests {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesCollectorComponent_whenKafkaZooKeeperUnset() {
+    context = new AnnotationConfigApplicationContext();
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(KafkaCollector.class);
+  }
+
+  @Test
+  public void providesCollectorComponent_whenZooKeeperSet() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.collector.kafka.zookeeper:localhost");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(KafkaCollector.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_port() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.collector.kafka.zookeeper:localhost",
+        "zipkin.collector.kafka.topic:zapkin"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinKafkaCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinKafkaCollectorProperties.class).getTopic())
+        .isEqualTo("zapkin");
+  }
+
+  @Configuration
+  static class InMemoryConfiguration {
+    @Bean CollectorSampler sampler() {
+      return CollectorSampler.ALWAYS_SAMPLE;
+    }
+
+    @Bean CollectorMetrics metrics() {
+      return CollectorMetrics.NOOP_METRICS;
+    }
+
+    @Bean StorageComponent storage() {
+      return new InMemoryStorage();
+    }
+  }
+}

--- a/zipkin-autoconfigure/collector-scribe/pom.xml
+++ b/zipkin-autoconfigure/collector-scribe/pom.xml
@@ -35,5 +35,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-collector-scribe</artifactId>
     </dependency>
+    <!-- Avoid javax.validation.ValidationException during tests -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>5.2.4.Final</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorProperties.java
+++ b/zipkin-autoconfigure/collector-scribe/src/main/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorProperties.java
@@ -16,7 +16,7 @@ package zipkin.autoconfigure.collector.scribe;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.collector.scribe.ScribeCollector;
 
-@ConfigurationProperties("scribe")
+@ConfigurationProperties("zipkin.collector.scribe")
 public class ZipkinScribeCollectorProperties {
   private String category = "zipkin";
   private int port = 9410;

--- a/zipkin-autoconfigure/collector-scribe/src/test/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/collector-scribe/src/test/java/zipkin/autoconfigure/collector/scribe/ZipkinScribeCollectorAutoConfigurationTests.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.collector.scribe;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.CollectorSampler;
+import zipkin.collector.scribe.ScribeCollector;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.StorageComponent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinScribeCollectorAutoConfigurationTests {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesCollectorComponent_whenDisabled() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.collector.scribe.enabled:false");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(ScribeCollector.class);
+  }
+
+  /** Note: this will flake if you happen to be running a server on port 9410! */
+  @Test
+  public void providesCollectorComponent() {
+    context = new AnnotationConfigApplicationContext();
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ScribeCollector.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_port() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.collector.scribe.port:9999");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinScribeCollectorAutoConfiguration.class, InMemoryConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinScribeCollectorProperties.class).getPort())
+        .isEqualTo(9999);
+  }
+
+  @Configuration
+  static class InMemoryConfiguration {
+    @Bean CollectorSampler sampler() {
+      return CollectorSampler.ALWAYS_SAMPLE;
+    }
+
+    @Bean CollectorMetrics metrics() {
+      return CollectorMetrics.NOOP_METRICS;
+    }
+
+    @Bean StorageComponent storage() {
+      return new InMemoryStorage();
+    }
+  }
+}

--- a/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/main/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageProperties.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.cassandra.CassandraStorage;
 
-@ConfigurationProperties("cassandra")
+@ConfigurationProperties("zipkin.storage.cassandra")
 public class ZipkinCassandraStorageProperties {
   private String keyspace = "zipkin";
   private String contactPoints = "localhost";

--- a/zipkin-autoconfigure/storage-cassandra/src/test/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/storage-cassandra/src/test/java/zipkin/autoconfigure/storage/cassandra/ZipkinCassandraStorageAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.cassandra;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.storage.cassandra.CassandraStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinCassandraStorageAutoConfigurationTests {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesStorageComponent_whenStorageTypeNotCassandra() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:elasticsearch");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(CassandraStorage.class);
+  }
+
+  @Test
+  public void providesStorageComponent_whenStorageTypeCassandra() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:cassandra");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(CassandraStorage.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_contactPoints() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:cassandra",
+        "zipkin.storage.cassandra.contact-points:host1,host2" // note snake-case supported
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinCassandraStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinCassandraStorageProperties.class).getContactPoints())
+        .isEqualTo("host1,host2");
+  }
+}

--- a/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/main/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageProperties.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import zipkin.storage.elasticsearch.ElasticsearchStorage;
 
-@ConfigurationProperties("elasticsearch")
+@ConfigurationProperties("zipkin.storage.elasticsearch")
 public class ZipkinElasticsearchStorageProperties {
   /**
    * The elasticsearch cluster to connect to, defaults to "elasticsearch".

--- a/zipkin-autoconfigure/storage-elasticsearch/src/test/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/storage-elasticsearch/src/test/java/zipkin/autoconfigure/storage/elasticsearch/ZipkinElasticsearchStorageAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.elasticsearch;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.storage.elasticsearch.ElasticsearchStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinElasticsearchStorageAutoConfigurationTests {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesStorageComponent_whenStorageTypeNotElasticsearch() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:cassandra");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchStorageAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(ElasticsearchStorage.class);
+  }
+
+  @Test
+  public void providesStorageComponent_whenStorageTypeElasticsearch() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:elasticsearch");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ElasticsearchStorage.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_hostsWithList() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:elasticsearch",
+        "zipkin.storage.elasticsearch.hosts:host1:9300,host2:9300"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinElasticsearchStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinElasticsearchStorageProperties.class).getHosts())
+        .containsExactly("host1:9300:host2:9300");
+  }
+}

--- a/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
+++ b/zipkin-autoconfigure/storage-mysql/src/main/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageProperties.java
@@ -15,7 +15,7 @@ package zipkin.autoconfigure.storage.mysql;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("mysql")
+@ConfigurationProperties("zipkin.storage.mysql")
 public class ZipkinMySQLStorageProperties {
   private String host = "localhost";
   private int port = 3306;

--- a/zipkin-autoconfigure/storage-mysql/src/test/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/storage-mysql/src/test/java/zipkin/autoconfigure/storage/mysql/ZipkinMySQLStorageAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.mysql;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.storage.mysql.MySQLStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinMySQLStorageAutoConfigurationTests {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void doesntProvidesStorageComponent_whenStorageTypeNotMySQL() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:cassandra");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinMySQLStorageAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(MySQLStorage.class);
+  }
+
+  @Test
+  public void providesStorageComponent_whenStorageTypeMySQL() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:mysql");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinMySQLStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(MySQLStorage.class)).isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_username() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:mysql",
+        "zipkin.storage.mysql.username:robot"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinMySQLStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinMySQLStorageProperties.class).getUsername())
+        .isEqualTo("robot");
+  }
+}

--- a/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
+++ b/zipkin-autoconfigure/ui/src/main/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfiguration.java
@@ -60,7 +60,6 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 @Configuration
 @EnableConfigurationProperties(ZipkinUiProperties.class)
 @RestController
-@ConditionalOnResource(resources = "classpath:zipkin-ui") // from io.zipkin:zipkin-ui
 public class ZipkinUiAutoConfiguration extends WebMvcConfigurerAdapter {
 
   @Autowired

--- a/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTests.java
+++ b/zipkin-autoconfigure/ui/src/test/java/zipkin/autoconfigure/ui/ZipkinUiAutoConfigurationTests.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.ui;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinUiAutoConfigurationTests {
+
+  AnnotationConfigApplicationContext context;
+
+  @After
+  public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test
+  public void indexHtmlFromClasspath() {
+    context = new AnnotationConfigApplicationContext();
+    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinUiAutoConfiguration.class).indexHtml)
+        .isNotNull();
+  }
+
+  @Test
+  public void canOverridesProperty_defaultLookback() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.ui.defaultLookback:100");
+    context.register(PropertyPlaceholderAutoConfiguration.class, ZipkinUiAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinUiProperties.class).getDefaultLookback())
+        .isEqualTo(100);
+  }
+}

--- a/zipkin-server/src/main/resources/zipkin-server.yml
+++ b/zipkin-server/src/main/resources/zipkin-server.yml
@@ -1,46 +1,3 @@
-cassandra:
-  # Comma separated list of hosts / ip addresses part of Cassandra cluster.
-  contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
-  # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
-  local-dc: ${CASSANDRA_LOCAL_DC:}
-  # Will throw an exception on startup if authentication fails.
-  username: ${CASSANDRA_USERNAME:}
-  password: ${CASSANDRA_PASSWORD:}
-  keyspace: ${CASSANDRA_KEYSPACE:zipkin}
-  # Max pooled connections per datacenter-local host.
-  max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
-  # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
-  ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
-  # 7 days in seconds
-  span-ttl: ${CASSANDRA_SPAN_TTL:604800}
-  # 3 days in seconds
-  index-ttl: ${CASSANDRA_INDEX_TTL:259200}
-mysql:
-  host: ${MYSQL_HOST:localhost}
-  port: ${MYSQL_TCP_PORT:3306}
-  username: ${MYSQL_USER:}
-  password: ${MYSQL_PASS:}
-  db: ${MYSQL_DB:zipkin}
-  max-active: ${MYSQL_MAX_CONNECTIONS:10}
-  use-ssl: ${MYSQL_USE_SSL:false}
-elasticsearch:
-  cluster: ${ES_CLUSTER:elasticsearch}
-  hosts: ${ES_HOSTS:localhost:9300}
-  index: ${ES_INDEX:zipkin}
-kafka:
-  # ZooKeeper host string, comma-separated host:port value.
-  zookeeper: ${KAFKA_ZOOKEEPER:}
-  # Name of topic to poll for spans
-  topic: ${KAFKA_TOPIC:zipkin}
-  # Consumer group this process is consuming on behalf of.
-  group-id: ${KAFKA_GROUP_ID:zipkin}
-  # Count of consumer threads consuming the topic
-  streams: ${KAFKA_STREAMS:1}
-  # Maximum size of a message containing spans in bytes
-  max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
-scribe:
-  category: zipkin
-  port: ${COLLECTOR_PORT:9410}
 zipkin:
   self-tracing:
     # Set to false to disable self-tracing. Defaults to true
@@ -50,6 +7,20 @@ zipkin:
   collector:
     # percentage to traces to retain
     sample-rate: ${COLLECTOR_SAMPLE_RATE:1.0}
+    kafka:
+      # ZooKeeper host string, comma-separated host:port value.
+      zookeeper: ${KAFKA_ZOOKEEPER:}
+      # Name of topic to poll for spans
+      topic: ${KAFKA_TOPIC:zipkin}
+      # Consumer group this process is consuming on behalf of.
+      group-id: ${KAFKA_GROUP_ID:zipkin}
+      # Count of consumer threads consuming the topic
+      streams: ${KAFKA_STREAMS:1}
+      # Maximum size of a message containing spans in bytes
+      max-message-size: ${KAFKA_MAX_MESSAGE_SIZE:1048576}
+    scribe:
+      category: zipkin
+      port: ${COLLECTOR_PORT:9410}
   query:
     # 7 days in millis
     lookback: ${QUERY_LOOKBACK:86400000}
@@ -57,6 +28,35 @@ zipkin:
     names-max-age: 300
   storage:
     type: ${STORAGE_TYPE:mem}
+    cassandra:
+      # Comma separated list of hosts / ip addresses part of Cassandra cluster.
+      contact-points: ${CASSANDRA_CONTACT_POINTS:localhost}
+      # Name of the datacenter that will be considered "local" for latency load balancing. When unset, load-balancing is round-robin.
+      local-dc: ${CASSANDRA_LOCAL_DC:}
+      # Will throw an exception on startup if authentication fails.
+      username: ${CASSANDRA_USERNAME:}
+      password: ${CASSANDRA_PASSWORD:}
+      keyspace: ${CASSANDRA_KEYSPACE:zipkin}
+      # Max pooled connections per datacenter-local host.
+      max-connections: ${CASSANDRA_MAX_CONNECTIONS:8}
+      # Ensuring that schema exists, if enabled tries to execute script /zipkin-cassandra-core/resources/cassandra-schema-cql3.txt.
+      ensure-schema: ${CASSANDRA_ENSURE_SCHEMA:true}
+      # 7 days in seconds
+      span-ttl: ${CASSANDRA_SPAN_TTL:604800}
+      # 3 days in seconds
+      index-ttl: ${CASSANDRA_INDEX_TTL:259200}
+    elasticsearch:
+      cluster: ${ES_CLUSTER:elasticsearch}
+      hosts: ${ES_HOSTS:localhost:9300}
+      index: ${ES_INDEX:zipkin}
+    mysql:
+      host: ${MYSQL_HOST:localhost}
+      port: ${MYSQL_TCP_PORT:3306}
+      username: ${MYSQL_USER:}
+      password: ${MYSQL_PASS:}
+      db: ${MYSQL_DB:zipkin}
+      max-active: ${MYSQL_MAX_CONNECTIONS:10}
+      use-ssl: ${MYSQL_USE_SSL:false}
   ui:
     ## Values below here are mapped to ZipkinServerProperties.UI, served as /config.json
     # Default limit for Find Traces


### PR DESCRIPTION
This is a second go at namespacing spring configuration. This time, it
includes tests. I've also manually built docker to make sure we didn't
break it.

See #235 (for last attempt)
Fixes #239