### PR TITLE
Exposes the underlying client in use by the storage component

### DIFF
--- a/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
+++ b/zipkin-storage/cassandra/src/main/java/zipkin/storage/cassandra/CassandraStorage.java
@@ -14,6 +14,7 @@
 
 package zipkin.storage.cassandra;
 
+import com.datastax.driver.core.Session;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -166,6 +167,11 @@ public final class CassandraStorage
     this.spanTtl = builder.spanTtl;
     this.bucketCount = builder.bucketCount;
     this.session = new LazySession(builder.sessionFactory, this);
+  }
+
+  /** Lazy initializes or returns the session in use by this storage component. */
+  public Session session() {
+    return session.get();
   }
 
   @Override protected CassandraSpanStore computeGuavaSpanStore() {

--- a/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
+++ b/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchStorage.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import zipkin.DependencyLink;
 import zipkin.internal.Util;
@@ -87,6 +88,11 @@ public final class ElasticsearchStorage
   ElasticsearchStorage(Builder builder) {
     lazyClient = new LazyClient(builder);
     indexNameFormatter = new IndexNameFormatter(builder.index);
+  }
+
+  /** Lazy initializes or returns the client in use by this storage component. */
+  public Client client() {
+    return lazyClient.get();
   }
 
   @Override protected ElasticsearchSpanStore computeGuavaSpanStore() {

--- a/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLStorage.java
+++ b/zipkin-storage/mysql/src/main/java/zipkin/storage/mysql/MySQLStorage.java
@@ -91,6 +91,11 @@ public final class MySQLStorage implements StorageComponent {
     this.asyncSpanConsumer = blockingToAsync(new MySQLSpanConsumer(datasource, context), executor);
   }
 
+  /** Returns the session in use by this storage component. */
+  public DataSource datasource() {
+    return datasource;
+  }
+
   @Override public SpanStore spanStore() {
     return spanStore;
   }


### PR DESCRIPTION
When integrating with other tools or testing, it is helpful to reuse
the same connection as zipkin does.