### PR TITLE
Teaches LazyCloseable to remember exceptions for a bit

### DIFF
--- a/zipkin/src/main/java/zipkin/internal/Lazy.java
+++ b/zipkin/src/main/java/zipkin/internal/Lazy.java
@@ -34,10 +34,19 @@ public abstract class Lazy<T> {
       synchronized (this) {
         result = instance;
         if (result == null) {
-          instance = result = compute();
+          instance = result = tryCompute();
         }
       }
     }
     return result;
+  }
+
+  /**
+   * This is called in a synchronized block when the value to memorize hasn't yet been computed.
+   *
+   * <p>Extracted only for LazyCloseable, hence package protection.
+   */
+  T tryCompute() {
+    return compute();
   }
 }

--- a/zipkin/src/main/java/zipkin/internal/LazyCloseable.java
+++ b/zipkin/src/main/java/zipkin/internal/LazyCloseable.java
@@ -15,10 +15,54 @@ package zipkin.internal;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static zipkin.internal.Util.checkArgument;
 
+/**
+ * This is a special-cased lazy with the following behaviors to support potentially expensive, I/O
+ * computations.
+ *
+ * <pre>
+ * <ul>
+ *   <li>Only closes computed values: this avoids accidentally causing I/O to close something
+ * never used.</li>
+ *   <li>Remembers exceptions for a second: this avoids repeated computation attempts, as doing so
+ * could harm the process or the backend</li>
+ * </ul>
+ * </pre>
+ */
 public abstract class LazyCloseable<T> extends Lazy<T> implements Closeable {
+
+  /** How long to cache an exception computing a value */
+  final long exceptionExpirationDuration = TimeUnit.SECONDS.toNanos(1);
+  // the below fields are guarded by this, and visible due to writes inside a synchronized block
+  RuntimeException lastException;
+  long exceptionExpiration;
+
+  @Override T tryCompute() {
+    // if last attempt was an exception, and we are within an cache interval, throw.
+    if (lastException != null) {
+      if (exceptionExpiration - nanoTime() <= 0) {
+        lastException = null;
+      } else {
+        throw lastException;
+      }
+    }
+    try {
+      return compute();
+    } catch (RuntimeException e) {
+      // this attempt failed. Remember the exception so that we can throw it.
+      lastException = e;
+      exceptionExpiration = nanoTime() + exceptionExpirationDuration;
+      throw e;
+    }
+  }
+
+  // visible for testing, since nanoTime is weird and can return negative
+  long nanoTime() {
+    return System.nanoTime();
+  }
 
   @Override
   public void close() throws IOException {

--- a/zipkin/src/test/java/zipkin/internal/LazyCloseableTest.java
+++ b/zipkin/src/test/java/zipkin/internal/LazyCloseableTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.internal;
+
+import java.io.Closeable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class LazyCloseableTest {
+  AtomicInteger callCount = new AtomicInteger();
+  TestLazyCloseable<Closeable> alwaysThrow = TestLazyCloseable.create(() -> {
+    callCount.incrementAndGet();
+    throw new RuntimeException();
+  });
+
+  TestLazyCloseable<Closeable> throwOnce = TestLazyCloseable.create(() -> {
+    if (callCount.incrementAndGet() == 1) {
+      throw new RuntimeException();
+    }
+    return (Closeable) () -> {
+    };
+  });
+
+  @Test
+  public void expiresExceptionWhenDurationPasses() throws InterruptedException {
+    throwOnce.nanoTime = 0;
+
+    expectExceptionOnGet(throwOnce);
+    assertThat(callCount.get()).isEqualTo(1);
+
+    // A second after the first call, we should try again
+    throwOnce.nanoTime = TimeUnit.SECONDS.toNanos(1);
+
+    assertThat(throwOnce.get()).isNotNull();
+    assertThat(callCount.get()).isEqualTo(2);
+
+    // sanity check that we cache from now on
+    assertThat(throwOnce.get()).isNotNull();
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+
+  /**
+   * This shows that any number of threads performing a failed computation only fail once.
+   */
+  @Test(timeout = 2000L) // 1000 for the gets + expiration (which is 1 second)
+  public void exception_memoizes() throws InterruptedException {
+    // tests an unmodified lazy closeable, which uses system nanos to manage expiration
+    LazyCloseable<Closeable> alwaysThrow = new LazyCloseable<Closeable>() {
+      @Override protected Closeable compute() {
+        throw new RuntimeException(String.valueOf(callCount.incrementAndGet()));
+      }
+    };
+
+    int getCount = 1000;
+    CountDownLatch latch = new CountDownLatch(getCount);
+    Executor exec = Executors.newFixedThreadPool(10);
+    for (int i = 0; i < getCount; i++) {
+      exec.execute(() -> {
+        expectExceptionOnGet(alwaysThrow);
+        latch.countDown();
+      });
+    }
+    latch.await();
+
+    assertThat(callCount.get()).isEqualTo(1);
+
+    // expire the exception
+    Thread.sleep(1000L);
+
+    // Sanity check: we don't memoize after we should have expired.
+    expectExceptionOnGet(alwaysThrow);
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void expiresExceptionWhenDurationPasses_initiallyNegative() throws InterruptedException {
+    alwaysThrow.nanoTime = -TimeUnit.SECONDS.toNanos(1);
+
+    expectExceptionOnGet(alwaysThrow);
+    assertThat(callCount.get()).isEqualTo(1);
+
+    // A second after the first call, we should try again
+    alwaysThrow.nanoTime = 0;
+
+    expectExceptionOnGet(alwaysThrow);
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+
+  void expectExceptionOnGet(Lazy<?> alwaysThrow) {
+    try {
+      alwaysThrow.get();
+      failBecauseExceptionWasNotThrown(RuntimeException.class);
+    } catch (RuntimeException e) {
+    }
+  }
+
+  static class TestLazyCloseable<T> extends LazyCloseable<T> {
+    static <T> TestLazyCloseable<T> create(Supplier<T> delegate) {
+      return new TestLazyCloseable<T>(delegate);
+    }
+
+    final Supplier<T> delegate;
+    long nanoTime;
+
+    protected TestLazyCloseable(Supplier<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override long nanoTime() {
+      return nanoTime;
+    }
+
+    @Override protected T compute() {
+      return delegate.get();
+    }
+  }
+}


### PR DESCRIPTION
Exceptions computing I/O intensive values can harm the process or the
backend. This teaches LazyCloseable to remember exceptions for a bit to
reduce that damage. The value is hard-set to 1 second which allows us
to mitigate the issue without adding a configuration burden.

Fixes #248