### PR TITLE
Adds docs on how storage tests run

### DIFF
--- a/zipkin-storage/cassandra/README.md
+++ b/zipkin-storage/cassandra/README.md
@@ -10,3 +10,20 @@ The CQL schema is the same as [zipkin-scala](https://github.com/openzipkin/zipki
 `zipkin.storage.cassandra.CassandraStorage.Builder` includes defaults that will
 operate against a local Cassandra installation.
 
+## Testing this component
+This module conditionally runs integration tests against a local Cassandra instance.
+
+Tests are configured to automatically access Cassandra started with its defaults.
+To ensure tests execute, download a Cassandra 2.2-3.4 distribution, extract it, and run `bin/cassandra`. 
+
+If you run tests via Maven or otherwise when Cassandra is not running,
+you'll notice tests are silently skipped.
+```
+Results :
+
+Tests run: 62, Failures: 0, Errors: 0, Skipped: 48
+```
+
+This behaviour is intentional: We don't want to burden developers with
+installing and running all storage options to test unrelated change.
+That said, all integration tests run on pull request via Travis.

--- a/zipkin-storage/elasticsearch/README.md
+++ b/zipkin-storage/elasticsearch/README.md
@@ -13,3 +13,20 @@ to remove indices older than the point you are interested in.
 `zipkin.storage.elasticsearch.ElasticsearchStorage.Builder` includes defaults
 that will operate against a local Elasticsearch installation.
 
+## Testing this component
+This module conditionally runs integration tests against a local Elasticsearch instance.
+
+Tests are configured to automatically access Elasticsearch started with its defaults.
+To ensure tests execute, download an Elasticsearch 2.x distribution, extract it, and run `bin/elasticsearch`. 
+
+If you run tests via Maven or otherwise when Elasticsearch is not running,
+you'll notice tests are silently skipped.
+```
+Results :
+
+Tests run: 50, Failures: 0, Errors: 0, Skipped: 48
+```
+
+This behaviour is intentional: We don't want to burden developers with
+installing and running all storage options to test unrelated change.
+That said, all integration tests run on pull request via Travis.

--- a/zipkin-storage/mysql/README.md
+++ b/zipkin-storage/mysql/README.md
@@ -10,6 +10,27 @@ The schema is the same as [zipkin-scala](https://github.com/openzipkin/zipkin/tr
 `zipkin.storage.mysql.MySQLStorage.Builder` includes defaults that will
 operate against a given Datasource.
 
+## Testing this component
+This module conditionally runs integration tests against a local MySQL instance.
+
+You minimally need to export the variable `MYSQL_USER` to run tests.
+Ex.
+```
+$ MYSQL_USER=root ./mvnw clean install -pl :zipkin-storage-mysql
+```
+
+If you run tests via Maven or otherwise without specifying `MYSQL_USER`,
+you'll notice tests are silently skipped.
+```
+Results :
+
+Tests run: 49, Failures: 0, Errors: 0, Skipped: 48
+```
+
+This behaviour is intentional: We don't want to burden developers with
+installing and running all storage options to test unrelated change.
+That said, all integration tests run on pull request via Travis.
+
 ## Exploring Zipkin Data
 
 When troubleshooting, it is important to note that zipkin ids are encoded as hex.


### PR DESCRIPTION
Some time back, we made sure developers aren't required to install and
run all data stores as a prerequisite of developing Zipkin. What we did
was made each of these conditional on environment, and skip integration
tests otherwise. We setup Travis such that all datastores are available,
so that no tests are skipped during pull requests.

What we didn't do was document what was going on, and this led to
confusion from different people who were curious about why pull requests
fail while local tests pass, or if integration tests run at all.